### PR TITLE
fix: macOS 14 호환성 및 swift run 실행 오류 수정

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,12 +3,20 @@ import PackageDescription
 
 let package = Package(
     name: "TokenGarden",
-    platforms: [.macOS(.v15)],
+    platforms: [.macOS(.v14)],
     targets: [
         .executableTarget(
             name: "TokenGarden",
             path: "TokenGarden",
-            exclude: ["Info.plist"]
+            exclude: ["Info.plist"],
+            linkerSettings: [
+                .unsafeFlags([
+                    "-Xlinker", "-sectcreate",
+                    "-Xlinker", "__TEXT",
+                    "-Xlinker", "__info_plist",
+                    "-Xlinker", "TokenGarden/Info.plist",
+                ]),
+            ]
         ),
         .testTarget(
             name: "TokenGardenTests",

--- a/TokenGarden/AppDelegate.swift
+++ b/TokenGarden/AppDelegate.swift
@@ -16,7 +16,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         NSApp.setActivationPolicy(.accessory)
 
         // SwiftData
-        modelContainer = try! ModelContainer(for: DailyUsage.self, ProjectUsage.self)
+        let config = ModelConfiguration(
+            "TokenGarden",
+            url: FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+                .appendingPathComponent("TokenGarden", isDirectory: true)
+                .appendingPathComponent("TokenGarden.store")
+        )
+        let supportDir = config.url.deletingLastPathComponent()
+        try? FileManager.default.createDirectory(at: supportDir, withIntermediateDirectories: true)
+        modelContainer = try! ModelContainer(for: DailyUsage.self, ProjectUsage.self, configurations: config)
         dataStore = TokenDataStore(modelContainer: modelContainer)
 
         // Status Item — fixed width to prevent menu bar shifting during animation

--- a/TokenGarden/Info.plist
+++ b/TokenGarden/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>CFBundleName</key>
+    <string>TokenGarden</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.rsquare.TokenGarden</string>
     <key>LSUIElement</key>
     <true/>
 </dict>

--- a/TokenGarden/MenuBar/AnimationFrames.swift
+++ b/TokenGarden/MenuBar/AnimationFrames.swift
@@ -1,5 +1,6 @@
 import AppKit
 
+@MainActor
 enum AnimationFrames {
     private static let size = NSSize(width: 18, height: 18)
 


### PR DESCRIPTION
## Summary
- Swift 6 concurrency 빌드 에러 수정 (`AnimationFrames`에 `@MainActor` 추가)
- 배포 타겟을 macOS 15 → macOS 14로 하향하여 Sonoma에서도 실행 가능
- `swift run` 시 SwiftData `Unable to determine Bundle Name` 크래시 수정 (Info.plist 바이너리 임베드 + 명시적 저장 경로)

## Test plan
- [ ] `swift build` 빌드 성공 확인
- [ ] `swift run TokenGarden` 크래시 없이 실행 확인
- [ ] macOS 14 (Sonoma) 환경에서 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)