### PR TITLE
fix: preserve profiles when ModelContainer reset is triggered

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,32 +35,78 @@ xcodebuild -scheme TokenGarden -destination 'platform=macOS' \
 
 ## Architecture
 
+Overview 탭은 **데이터 레이어와 UI 레이어가 분리된 MVVM 구조**로 동작합니다. 메뉴바 클릭 시 SwiftData fetch가 main thread를 막지 않도록, VM이 앱 시작 시 백그라운드에서 미리 데이터를 로드합니다.
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ UI Layer  (Views, dumb)                                 │
+│   PopoverView → VM의 snapshot을 읽기만 함                 │
+│   · HeatmapView, StatsView, HourlyChartView, ...        │
+└─────────────────────────────────────────────────────────┘
+                    ↑ OverviewSnapshot (Sendable)
+┌─────────────────────────────────────────────────────────┐
+│ ViewModel Layer  (@Observable, @MainActor)              │
+│   OverviewViewModel — isInitialLoading, snapshot,       │
+│                       selectedDate, active hourly       │
+└─────────────────────────────────────────────────────────┘
+                    ↑ await repo.loadSnapshot()
+┌─────────────────────────────────────────────────────────┐
+│ Repository Layer  (@ModelActor, background executor)    │
+│   OverviewRepository — SwiftData fetch + aggregation    │
+│                        → returns Sendable snapshot      │
+└─────────────────────────────────────────────────────────┘
+```
+
 ```
 TokenGarden/
-├── AppDelegate.swift              # 앱 초기화, 메뉴바, 팝오버
+├── AppDelegate.swift              # 앱 초기화, VM 생성/주입, 메뉴바, 팝오버
 ├── MenuBar/
 │   ├── MenuBarController.swift    # 상태바 표시 (아이콘/텍스트/그래프)
 │   └── AnimationFrames.swift      # 식물 성장 애니메이션 (5프레임)
 ├── Services/
-│   ├── TokenDataStore.swift       # SwiftData 저장소
+│   ├── TokenDataStore.swift       # SwiftData 쓰기 경로 (record + flush)
+│   ├── OverviewRepository.swift   # @ModelActor 읽기 경로, Snapshot 생성
 │   ├── LogWatcher.swift           # FSEventStream 파일 감시
 │   └── UpdateChecker.swift        # GitHub release 업데이트 체크
+├── ViewModels/
+│   └── OverviewViewModel.swift    # @Observable, Overview 탭 상태 관리
 ├── Parsers/
 │   └── ClaudeCodeLogParser.swift  # JSONL 로그 파싱
 ├── Models/
 │   ├── DailyUsage.swift           # 일별 집계 (@Model)
 │   ├── SessionUsage.swift         # 세션 추적 (@Model)
 │   ├── ProjectUsage.swift         # 프로젝트별 집계 (@Model)
+│   ├── HourlyUsage.swift          # 시간대별 집계 (@Model)
+│   ├── OverviewSnapshot.swift     # Sendable value type (UI가 읽는 데이터)
 │   ├── TokenEvent.swift           # 파싱된 이벤트
-│   └── HeatmapTheme.swift        # 컬러 테마
+│   └── HeatmapTheme.swift         # 컬러 테마
+├── Utilities/
+│   ├── ExpandAnimation.swift      # 섹션 펼치기/접기 공통 애니메이션
+│   ├── DebouncedPersistence.swift # 저장 debounce
+│   └── ProcessRunner.swift        # 외부 프로세스 실행
 └── Views/
-    ├── PopoverView.swift          # 메인 팝오버
+    ├── PopoverView.swift          # 메인 팝오버 (탭 컨테이너, 고정 높이)
+    ├── PulseSkeleton.swift        # 로딩 중 placeholder (pulse 애니메이션)
     ├── HeatmapView.swift          # 캘린더 히트맵
     ├── StatsView.swift            # 통계 카드
+    ├── HourlyChartView.swift      # 시간대별 차트
     ├── ProjectListView.swift      # 프로젝트 목록
     ├── SessionListView.swift      # 활성 세션 목록
+    ├── AccountsTabView.swift      # 계정별 사용량 탭
     └── SettingsView.swift         # 설정
 ```
+
+## Testing
+
+Swift Testing 기반 단위 테스트. `xcodebuild test`로 실행:
+
+```bash
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
+xcodebuild test -scheme TokenGarden -destination 'platform=macOS' \
+  -derivedDataPath .claude/tmp/DerivedData
+```
+
+테스트는 in-memory `ModelContainer`를 사용해 실제 DB 없이 실행됩니다.
 
 ## License
 

--- a/TokenGarden/AppDelegate.swift
+++ b/TokenGarden/AppDelegate.swift
@@ -41,18 +41,22 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         do {
             modelContainer = try ModelContainer(for: schema, configurations: [config])
         } catch {
-            // Backup profiles before reset
-            let backupProfiles = Self.backupProfiles(from: storeURL)
+            // Backup profiles before reset — checkpoints WAL so recently-saved
+            // rows that only exist in the write-ahead log are visible.
+            let backup = Self.backupProfiles(from: storeURL)
 
-            // New model added — reset store and backfill offsets to rebuild from logs
+            // Preserve the old store instead of deleting it. A failed backup
+            // (couldn't open DB, prepare failed, etc.) must not lead to silent
+            // data loss — the previous store is renamed to a timestamped
+            // sibling so users can recover manually.
             let storeDir = storeURL.deletingLastPathComponent()
-            try? FileManager.default.removeItem(at: storeDir)
+            Self.archiveStoreFiles(in: storeDir, storeName: storeURL.lastPathComponent)
             try? FileManager.default.createDirectory(at: storeDir, withIntermediateDirectories: true)
             UserDefaults.standard.removeObject(forKey: "LogWatcherOffsets")
             modelContainer = try! ModelContainer(for: schema, configurations: [config])
 
             // Restore profiles after reset
-            Self.restoreProfiles(backupProfiles, into: modelContainer.mainContext)
+            Self.restoreProfiles(backup.profiles, into: modelContainer.mainContext)
         }
         dataStore = TokenDataStore(modelContainer: modelContainer)
 
@@ -190,7 +194,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Profile Backup/Restore (survives DB reset)
 
-    private struct ProfileBackup: Codable {
+    struct ProfileBackup: Codable {
         let name: String
         let email: String
         let plan: String
@@ -200,15 +204,39 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let colorName: String
     }
 
-    private static func backupProfiles(from storeURL: URL) -> [ProfileBackup] {
-        // Read profiles directly via SQLite before DB is destroyed
+    /// Result of a profile backup attempt.
+    /// `didReadDatabase` distinguishes "DB opened and table read successfully"
+    /// (empty result means no profiles) from "could not read at all" (schema
+    /// mismatch, locked DB, missing file — empty result is not authoritative).
+    struct ProfileBackupResult {
+        let profiles: [ProfileBackup]
+        let didReadDatabase: Bool
+    }
+
+    static func backupProfiles(from storeURL: URL) -> ProfileBackupResult {
+        // Read profiles directly via SQLite before DB is destroyed.
+        guard FileManager.default.fileExists(atPath: storeURL.path) else {
+            return ProfileBackupResult(profiles: [], didReadDatabase: false)
+        }
+
         var db: OpaquePointer?
-        guard sqlite3_open(storeURL.path, &db) == SQLITE_OK else { return [] }
+        guard sqlite3_open(storeURL.path, &db) == SQLITE_OK else {
+            return ProfileBackupResult(profiles: [], didReadDatabase: false)
+        }
         defer { sqlite3_close(db) }
+
+        // Fold any WAL rows into the main DB before reading. If the previous
+        // app instance crashed before a checkpoint (e.g., right after saving
+        // a profile), those rows only exist in the WAL and a naive
+        // `sqlite3_open` + SELECT would miss them, causing the subsequent
+        // reset path to silently destroy unbacked-up profiles.
+        sqlite3_exec(db, "PRAGMA wal_checkpoint(TRUNCATE)", nil, nil, nil)
 
         var stmt: OpaquePointer?
         let sql = "SELECT ZNAME, ZEMAIL, ZPLAN, ZCREDENTIALSJSON, ZISACTIVE, ZMONTHLYLIMIT, ZCOLORNAME FROM ZPROFILE"
-        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return [] }
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            return ProfileBackupResult(profiles: [], didReadDatabase: false)
+        }
         defer { sqlite3_finalize(stmt) }
 
         var backups: [ProfileBackup] = []
@@ -234,7 +262,23 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 monthlyLimit: monthlyLimit, colorName: colorName
             ))
         }
-        return backups
+        return ProfileBackupResult(profiles: backups, didReadDatabase: true)
+    }
+
+    /// Renames the existing store files to a timestamped archive next to the
+    /// store directory. This preserves data on schema-migration failures so a
+    /// user or developer can recover manually, instead of silently deleting it.
+    static func archiveStoreFiles(in storeDir: URL, storeName: String) {
+        let fm = FileManager.default
+        let suffixes = ["", "-shm", "-wal"]
+        let timestamp = ISO8601DateFormatter().string(from: Date())
+            .replacingOccurrences(of: ":", with: "-")
+        for suffix in suffixes {
+            let src = storeDir.appendingPathComponent(storeName + suffix)
+            guard fm.fileExists(atPath: src.path) else { continue }
+            let dst = storeDir.appendingPathComponent("\(storeName).corrupted-\(timestamp)\(suffix)")
+            try? fm.moveItem(at: src, to: dst)
+        }
     }
 
     private static func restoreProfiles(_ backups: [ProfileBackup], into context: ModelContext) {

--- a/TokenGarden/AppDelegate.swift
+++ b/TokenGarden/AppDelegate.swift
@@ -15,9 +15,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var updateChecker: UpdateChecker!
     private var profileManager: ProfileManager!
 
-    // Session refresh: background thread writes, main thread reads
-    private nonisolated(unsafe) let refreshLock = NSLock()
-    private nonisolated(unsafe) var pendingActiveProjects: Set<String>?
+    // Session refresh via structured concurrency
+    private var sessionRefreshTask: Task<Void, Never>?
     private var lastBalancedSessionId: String?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -75,11 +74,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // MenuBar Controller
         menuBarController = MenuBarController(statusItem: statusItem, initialTodayTokens: 0, initialHourlyBuckets: [0, 0, 0])
 
-        // Animation timer — also checks for pending session refresh
+        // Animation timer — tick() itself handles dirty tracking to skip redundant renders
         animationTimer = Timer(timeInterval: 0.5, repeats: true) { [weak self] _ in
             MainActor.assumeIsolated {
                 self?.menuBarController.tick()
-                self?.applyPendingRefreshIfNeeded()
             }
         }
         RunLoop.main.add(animationTimer, forMode: .common)
@@ -96,6 +94,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             .environmentObject(menuBarController)
             .environmentObject(updateChecker)
             .environmentObject(profileManager)
+            .environmentObject(dataStore)
             .modelContainer(modelContainer)
         let hostingController = NSHostingController(rootView: popoverView)
         hostingController.sizingOptions = .preferredContentSize
@@ -145,42 +144,35 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         profileManager.startTokenKeeper()
     }
 
-    /// Run refresh immediately on background, result applied on next timer tick
+    /// Run refresh once on background, apply result on main actor.
     private func triggerRefresh() {
-        DispatchQueue.global(qos: .utility).async { [weak self] in
-            let projects = TokenDataStore.getActiveClaudeProjects()
-            self?.refreshLock.lock()
-            self?.pendingActiveProjects = projects
-            self?.refreshLock.unlock()
-        }
-    }
-
-    // MARK: - Session Refresh (background → main via polling)
-
-    private func startSessionRefreshLoop() {
-        Thread.detachNewThread { [weak self] in
-
-            while true {
-                let projects = TokenDataStore.getActiveClaudeProjects()
-
-                self?.refreshLock.lock()
-                self?.pendingActiveProjects = projects
-                self?.refreshLock.unlock()
-                Thread.sleep(forTimeInterval: 30)
+        Task.detached(priority: .utility) { [weak self] in
+            let projects = await TokenDataStore.getActiveClaudeProjects()
+            await MainActor.run {
+                self?.dataStore.applyActiveStatus(activeProjects: projects)
             }
         }
     }
 
-    private func applyPendingRefreshIfNeeded() {
-        refreshLock.lock()
-        let projects = pendingActiveProjects
-        pendingActiveProjects = nil
-        refreshLock.unlock()
+    // MARK: - Session Refresh (structured concurrency)
 
-        if let projects {
-
-            dataStore.applyActiveStatus(activeProjects: projects)
+    private func startSessionRefreshLoop() {
+        sessionRefreshTask = Task.detached(priority: .utility) { [weak self] in
+            while !Task.isCancelled {
+                let projects = await TokenDataStore.getActiveClaudeProjects()
+                if Task.isCancelled { return }
+                await MainActor.run {
+                    self?.dataStore.applyActiveStatus(activeProjects: projects)
+                }
+                try? await Task.sleep(for: .seconds(30))
+            }
         }
+    }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        sessionRefreshTask?.cancel()
+        sessionRefreshTask = nil
+        logWatcher?.stop()
     }
 
     // MARK: - Popover

--- a/TokenGarden/AppDelegate.swift
+++ b/TokenGarden/AppDelegate.swift
@@ -14,6 +14,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var animationTimer: Timer!
     private var updateChecker: UpdateChecker!
     private var profileManager: ProfileManager!
+    private var overviewViewModel: OverviewViewModel!
 
     // Session refresh via structured concurrency
     private var sessionRefreshTask: Task<Void, Never>?
@@ -86,6 +87,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         updateChecker = UpdateChecker()
         updateChecker.check()
 
+        // Overview View Model — starts loading data immediately so it's
+        // already in memory by the time the user clicks the menu bar.
+        overviewViewModel = OverviewViewModel(modelContainer: modelContainer)
+        overviewViewModel.start()
+
         // Popover
         popover = NSPopover()
         popover.behavior = .transient
@@ -95,6 +101,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             .environmentObject(updateChecker)
             .environmentObject(profileManager)
             .environmentObject(dataStore)
+            .environment(overviewViewModel)
             .modelContainer(modelContainer)
         let hostingController = NSHostingController(rootView: popoverView)
         hostingController.sizingOptions = .preferredContentSize
@@ -106,6 +113,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             guard let event = parser.parse(logLine: line) else { return }
             self?.dataStore.record(event)
             self?.menuBarController.onTokenEvent(event)
+            self?.overviewViewModel.onTokenEvent()
 
             // Auto-balance only when session changes
             if let sessionId = event.sessionId,
@@ -133,6 +141,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             ).first?.totalTokens ?? 0
             let hourlyBuckets = self?.dataStore.fetchHourlyBuckets() ?? [0, 0, 0]
             self?.menuBarController.reloadData(todayTokens: todayTokens, hourlyBuckets: hourlyBuckets)
+            // Backfill finished — kick a fresh snapshot so the VM sees the
+            // newly persisted data.
+            self?.overviewViewModel.refresh()
         }
 
 

--- a/TokenGarden/MenuBar/MenuBarController.swift
+++ b/TokenGarden/MenuBar/MenuBarController.swift
@@ -14,6 +14,11 @@ class MenuBarController: ObservableObject {
     private var bucketHours: [Int] = [-1, -1, -1]
     private var lastKnownDay: Date = .distantPast
 
+    // Dirty tracking — skip NSImage rendering when nothing visible has changed
+    private var needsDisplayUpdate = true
+    private var lastActivityTime: Date = .distantPast
+    private let idleTimeout: TimeInterval = 60  // stop animation after 60s of no events
+
     init(
         statusItem: NSStatusItem,
         initialTodayTokens: Int = 0,
@@ -30,6 +35,7 @@ class MenuBarController: ObservableObject {
             self.hourlyBuckets = initialHourlyBuckets
         }
         updateDisplay()
+        needsDisplayUpdate = false
     }
 
     func onTokenEvent(_ event: TokenEvent) {
@@ -41,7 +47,10 @@ class MenuBarController: ObservableObject {
         if let idx = bucketHours.firstIndex(of: hour) {
             hourlyBuckets[idx] += event.totalTokens
         }
+        lastActivityTime = Date()
+        needsDisplayUpdate = true
         updateDisplay()
+        needsDisplayUpdate = false
     }
 
     /// Reload data after async backfill completes
@@ -50,21 +59,41 @@ class MenuBarController: ObservableObject {
         if hourlyBuckets.count == 3 {
             self.hourlyBuckets = hourlyBuckets
         }
+        needsDisplayUpdate = true
         updateDisplay()
+        needsDisplayUpdate = false
     }
 
-    /// Called by AppDelegate's timer on every tick
+    /// Called by AppDelegate's timer on every tick.
+    /// Skips frame advance and rendering when idle (no token events in last 60s).
     func tick() {
-        currentFrame = (currentFrame + 1) % AnimationFrames.frameCount
-        refreshBucketHours()
-        updateDisplay()
+        let isActive = Date().timeIntervalSince(lastActivityTime) < idleTimeout
+
+        if isActive {
+            // Animation only runs while recent activity — advances frame and redraws
+            currentFrame = (currentFrame + 1) % AnimationFrames.frameCount
+            needsDisplayUpdate = true
+        }
+
+        let hourChanged = refreshBucketHours()
+        if hourChanged {
+            needsDisplayUpdate = true
+        }
+
+        if needsDisplayUpdate {
+            updateDisplay()
+            needsDisplayUpdate = false
+        }
     }
 
     // MARK: - Private
 
-    private func refreshBucketHours() {
+    /// Refreshes day/hour state. Returns true if anything observable changed (day rollover or hour shift).
+    @discardableResult
+    private func refreshBucketHours() -> Bool {
         let cal = Calendar.current
         let now = Date()
+        var changed = false
 
         // Reset all state when the day changes
         let today = cal.startOfDay(for: now)
@@ -73,6 +102,7 @@ class MenuBarController: ObservableObject {
             todayTokens = 0
             hourlyBuckets = [0, 0, 0]
             bucketHours = [-1, -1, -1]
+            changed = true
         }
 
         let currentHour = cal.component(.hour, from: now)
@@ -87,7 +117,9 @@ class MenuBarController: ObservableObject {
             }
             hourlyBuckets = newBuckets
             bucketHours = expected
+            changed = true
         }
+        return changed
     }
 
     private func updateDisplay() {

--- a/TokenGarden/Models/OverviewSnapshot.swift
+++ b/TokenGarden/Models/OverviewSnapshot.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Value-type, Sendable snapshot of the data shown in the Overview tab.
+///
+/// The view layer only ever reads one of these — it never touches SwiftData
+/// objects directly. This decouples UI from DB fetching and eliminates
+/// SwiftData relationship faulting on the main thread when the popover opens.
+struct OverviewSnapshot: Sendable, Equatable {
+    var todayTokens: Int
+    var weekTokens: Int
+    var monthTokens: Int
+    var heatmapData: [HeatmapCell]
+    var hourlyTokens: [Int]              // 24-slot array, indexed by hour of day
+    var todayProjects: [ProjectSummary]
+    var weekProjects: [ProjectSummary]
+    var monthProjects: [ProjectSummary]
+    var activeSessions: [SessionSummary]
+    var hasAnyData: Bool
+
+    static let empty = OverviewSnapshot(
+        todayTokens: 0,
+        weekTokens: 0,
+        monthTokens: 0,
+        heatmapData: [],
+        hourlyTokens: Array(repeating: 0, count: 24),
+        todayProjects: [],
+        weekProjects: [],
+        monthProjects: [],
+        activeSessions: [],
+        hasAnyData: false
+    )
+}
+
+/// Single heatmap cell data — detached from SwiftData's `DailyUsage`.
+struct HeatmapCell: Sendable, Equatable, Hashable {
+    let date: Date
+    let tokens: Int
+}
+
+/// Project aggregate for a time range.
+struct ProjectSummary: Sendable, Equatable, Hashable, Identifiable {
+    let name: String
+    let tokens: Int
+    var id: String { name }
+}
+
+/// Active session summary — detached from SwiftData's `SessionUsage`.
+struct SessionSummary: Sendable, Equatable, Hashable, Identifiable {
+    let sessionId: String
+    let projectName: String
+    let startTime: Date
+    let lastTime: Date
+    let totalTokens: Int
+    var id: String { sessionId }
+}

--- a/TokenGarden/Services/CredentialsManager.swift
+++ b/TokenGarden/Services/CredentialsManager.swift
@@ -25,27 +25,19 @@ struct CredentialsManager {
     @discardableResult
     func writeCredentials(_ data: Data) -> Bool {
         guard let json = String(data: data, encoding: .utf8) else { return false }
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/security")
-        process.arguments = ["add-generic-password", "-s", Self.keychainService, "-a", Self.keychainAccount, "-w", json, "-U"]
-        process.standardOutput = FileHandle.nullDevice
-        process.standardError = FileHandle.nullDevice
-        try? process.run()
-        process.waitUntilExit()
-        return process.terminationStatus == 0
+        let result = ProcessRunner.runSync(
+            executable: "/usr/bin/security",
+            arguments: ["add-generic-password", "-s", Self.keychainService, "-a", Self.keychainAccount, "-w", json, "-U"]
+        )
+        return result.succeeded
     }
 
     private static func currentKeychainData() -> Data? {
-        let pipe = Pipe()
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/security")
-        process.arguments = ["find-generic-password", "-s", keychainService, "-a", keychainAccount, "-w"]
-        process.standardOutput = pipe
-        process.standardError = FileHandle.nullDevice
-        try? process.run()
-        process.waitUntilExit()
-        let raw = pipe.fileHandleForReading.readDataToEndOfFile()
-        guard let str = String(data: raw, encoding: .utf8)?
+        let result = ProcessRunner.runSync(
+            executable: "/usr/bin/security",
+            arguments: ["find-generic-password", "-s", keychainService, "-a", keychainAccount, "-w"]
+        )
+        guard let str = result.outputString?
             .trimmingCharacters(in: .whitespacesAndNewlines),
               !str.isEmpty else { return nil }
         return str.data(using: .utf8)
@@ -72,24 +64,16 @@ struct CredentialsManager {
             return fetchAuthStatusFromKeychain()
         }
 
-        let pipe = Pipe()
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: claude)
-        process.arguments = ["auth", "status"]
-        process.standardOutput = pipe
-        process.standardError = FileHandle.nullDevice
-        // Ensure HOME is set for claude to find its config
-        process.environment = ProcessInfo.processInfo.environment
-
-        do {
-            try process.run()
-            process.waitUntilExit()
-        } catch {
+        let result = ProcessRunner.runSync(
+            executable: claude,
+            arguments: ["auth", "status"],
+            environment: ProcessInfo.processInfo.environment
+        )
+        guard result.succeeded else {
             return fetchAuthStatusFromKeychain()
         }
 
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+        guard let json = try? JSONSerialization.jsonObject(with: result.output) as? [String: Any],
               let loggedIn = json["loggedIn"] as? Bool, loggedIn,
               let email = json["email"] as? String,
               let subscriptionType = json["subscriptionType"] as? String
@@ -144,7 +128,7 @@ struct CredentialsManager {
 
     /// Fetches real-time rate limit utilization via a minimal API call.
     /// Parses `anthropic-ratelimit-unified-*` response headers.
-    nonisolated static func fetchUsageLimits(oauthToken: String) -> UsageLimits? {
+    nonisolated static func fetchUsageLimits(oauthToken: String) async -> UsageLimits? {
         guard let url = URL(string: "https://api.anthropic.com/v1/messages") else { return nil }
 
         var request = URLRequest(url: url, timeoutInterval: 10)
@@ -160,37 +144,30 @@ struct CredentialsManager {
         ]
         request.httpBody = try? JSONSerialization.data(withJSONObject: body)
 
-        let semaphore = DispatchSemaphore(value: 0)
-        var result: UsageLimits?
+        guard let (_, response) = try? await URLSession.shared.data(for: request),
+              let http = response as? HTTPURLResponse else { return nil }
 
-        URLSession.shared.dataTask(with: request) { _, response, _ in
-            defer { semaphore.signal() }
-            guard let http = response as? HTTPURLResponse else { return }
-            let h = http.allHeaderFields as? [String: String] ?? [:]
+        let headers = http.allHeaderFields as? [String: String] ?? [:]
 
-            func doubleHeader(_ key: String) -> Double? {
-                h.first(where: { $0.key.lowercased() == key })
-                    .flatMap { Double($0.value) }
-            }
-            func dateHeader(_ key: String) -> Date? {
-                doubleHeader(key).map { Date(timeIntervalSince1970: $0) }
-            }
+        func doubleHeader(_ key: String) -> Double? {
+            headers.first(where: { $0.key.lowercased() == key })
+                .flatMap { Double($0.value) }
+        }
+        func dateHeader(_ key: String) -> Date? {
+            doubleHeader(key).map { Date(timeIntervalSince1970: $0) }
+        }
 
-            guard let fiveUtil = doubleHeader("anthropic-ratelimit-unified-5h-utilization"),
-                  let fiveReset = dateHeader("anthropic-ratelimit-unified-5h-reset"),
-                  let sevenUtil = doubleHeader("anthropic-ratelimit-unified-7d-utilization"),
-                  let sevenReset = dateHeader("anthropic-ratelimit-unified-7d-reset")
-            else { return }
+        guard let fiveUtil = doubleHeader("anthropic-ratelimit-unified-5h-utilization"),
+              let fiveReset = dateHeader("anthropic-ratelimit-unified-5h-reset"),
+              let sevenUtil = doubleHeader("anthropic-ratelimit-unified-7d-utilization"),
+              let sevenReset = dateHeader("anthropic-ratelimit-unified-7d-reset")
+        else { return nil }
 
-            result = UsageLimits(
-                fiveHourUtilization: fiveUtil,
-                fiveHourResetAt: fiveReset,
-                sevenDayUtilization: sevenUtil,
-                sevenDayResetAt: sevenReset
-            )
-        }.resume()
-
-        semaphore.wait()
-        return result
+        return UsageLimits(
+            fiveHourUtilization: fiveUtil,
+            fiveHourResetAt: fiveReset,
+            sevenDayUtilization: sevenUtil,
+            sevenDayResetAt: sevenReset
+        )
     }
 }

--- a/TokenGarden/Services/LogWatcher.swift
+++ b/TokenGarden/Services/LogWatcher.swift
@@ -7,10 +7,12 @@ class LogWatcher {
     private var stream: FSEventStreamRef?
     private var fileOffsets: [String: Int] = [:]
     private let offsetsKey = "LogWatcherOffsets"
+    private let debouncedSave: DebouncedPersistence
 
     init(watchPaths: [String], onNewLine: @escaping @MainActor (String) -> Void) {
         self.watchPaths = watchPaths
         self.onNewLine = onNewLine
+        self.debouncedSave = DebouncedPersistence(key: "LogWatcherOffsets", delay: 2.0)
         loadOffsets()
     }
 
@@ -40,7 +42,7 @@ class LogWatcher {
         FSEventStreamInvalidate(stream)
         FSEventStreamRelease(stream)
         self.stream = nil
-        saveOffsets()
+        debouncedSave.flushNow()
     }
 
     nonisolated private static let eventCallback: FSEventStreamCallback = { _, info, numEvents, eventPaths, _, _ in
@@ -76,7 +78,7 @@ class LogWatcher {
 
         let data = handle.readDataToEndOfFile()
         fileOffsets[path] = Int(handle.offsetInFile)
-        saveOffsets()
+        debouncedSave.schedule(fileOffsets)
 
         guard let content = String(data: data, encoding: .utf8) else { return }
         let lines = content.components(separatedBy: .newlines)
@@ -87,6 +89,9 @@ class LogWatcher {
 
     /// Backfill on background thread. Reads files and parses lines off-main,
     /// then delivers parsed TokenEvents to the callback in batches.
+    ///
+    /// Scans `<watchPath>/projects/` first (Claude Code's actual log location).
+    /// Falls back to full recursive enumeration if that path doesn't exist.
     func backfill(parser: ClaudeCodeLogParser, onEvent: @escaping @MainActor (TokenEvent) -> Void, completion: @escaping @MainActor () -> Void = {}) {
         let currentOffsets = fileOffsets
         let paths = watchPaths
@@ -96,11 +101,15 @@ class LogWatcher {
             var newOffsets: [String: Int] = [:]
 
             for watchPath in paths {
-                guard let enumerator = FileManager.default.enumerator(atPath: watchPath) else { continue }
+                // Prefer targeted projects/ subdirectory
+                let projectsPath = (watchPath as NSString).appendingPathComponent("projects")
+                let rootPath = FileManager.default.fileExists(atPath: projectsPath) ? projectsPath : watchPath
+
+                guard let enumerator = FileManager.default.enumerator(atPath: rootPath) else { continue }
                 while let relativePath = enumerator.nextObject() as? String {
                     guard relativePath.hasSuffix(".jsonl"),
                           !URL(fileURLWithPath: relativePath).lastPathComponent.contains("compact") else { continue }
-                    let fullPath = (watchPath as NSString).appendingPathComponent(relativePath)
+                    let fullPath = (rootPath as NSString).appendingPathComponent(relativePath)
                     guard currentOffsets[fullPath] == nil else { continue }
 
                     guard let handle = FileHandle(forReadingAtPath: fullPath) else { continue }
@@ -124,7 +133,7 @@ class LogWatcher {
                     for (path, offset) in newOffsets {
                         self.fileOffsets[path] = offset
                     }
-                    self.saveOffsets()
+                    self.debouncedSave.schedule(self.fileOffsets)
                     for event in events {
                         onEvent(event)
                     }
@@ -136,9 +145,5 @@ class LogWatcher {
 
     private func loadOffsets() {
         fileOffsets = UserDefaults.standard.dictionary(forKey: offsetsKey) as? [String: Int] ?? [:]
-    }
-
-    private func saveOffsets() {
-        UserDefaults.standard.set(fileOffsets, forKey: offsetsKey)
     }
 }

--- a/TokenGarden/Services/OverviewRepository.swift
+++ b/TokenGarden/Services/OverviewRepository.swift
@@ -1,0 +1,130 @@
+import Foundation
+import SwiftData
+
+/// Background SwiftData worker that produces `OverviewSnapshot` value objects.
+///
+/// Uses the `@ModelActor` macro so all fetches run on the actor's executor —
+/// never blocking the main thread. Callers await the result and receive
+/// Sendable values, so SwiftData entities never leak into the UI layer.
+@ModelActor
+actor OverviewRepository {
+    /// Fetch everything the Overview tab needs and roll it up into a
+    /// `Sendable` value type. Relationship faulting happens here on the
+    /// background executor, so the main thread never pays for it.
+    func loadSnapshot(referenceDate: Date = Date()) -> OverviewSnapshot {
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: referenceDate)
+
+        var weekCal = calendar
+        weekCal.firstWeekday = 2
+        let weekStart = weekCal.dateComponents(
+            [.calendar, .yearForWeekOfYear, .weekOfYear],
+            from: referenceDate
+        ).date ?? today
+
+        let monthComps = calendar.dateComponents([.year, .month], from: referenceDate)
+        let monthStart = calendar.date(from: monthComps) ?? today
+
+        // 1. Daily usages (drives heatmap, stats, project breakdowns)
+        var dailyDescriptor = FetchDescriptor<DailyUsage>()
+        dailyDescriptor.sortBy = [SortDescriptor(\DailyUsage.date)]
+        let dailies = (try? modelContext.fetch(dailyDescriptor)) ?? []
+
+        var todayTokens = 0
+        var weekTokens = 0
+        var monthTokens = 0
+        var heatmapData: [HeatmapCell] = []
+        heatmapData.reserveCapacity(dailies.count)
+
+        var todayProjectTotals: [String: Int] = [:]
+        var weekProjectTotals: [String: Int] = [:]
+        var monthProjectTotals: [String: Int] = [:]
+
+        for daily in dailies {
+            let dailyTotal = daily.totalTokens
+            heatmapData.append(HeatmapCell(date: daily.date, tokens: dailyTotal))
+
+            if daily.date == today { todayTokens = dailyTotal }
+            if daily.date >= weekStart { weekTokens += dailyTotal }
+            if daily.date >= monthStart { monthTokens += dailyTotal }
+
+            // Relationship faulting happens on background executor — safe.
+            for project in daily.projectBreakdowns {
+                let name = project.projectName
+                let t = project.tokens
+                if daily.date == today {
+                    todayProjectTotals[name, default: 0] += t
+                }
+                if daily.date >= weekStart {
+                    weekProjectTotals[name, default: 0] += t
+                }
+                if daily.date >= monthStart {
+                    monthProjectTotals[name, default: 0] += t
+                }
+            }
+        }
+
+        // 2. Hourly tokens for today (reuses same logic as loadHourlyTokens)
+        let hourlyTokens = loadHourlyTokens(for: today)
+
+        // 3. Active sessions
+        var sessionDescriptor = FetchDescriptor<SessionUsage>(
+            predicate: #Predicate<SessionUsage> { $0.isActive == true }
+        )
+        sessionDescriptor.sortBy = [SortDescriptor(\SessionUsage.lastTime, order: .reverse)]
+        let sessions = (try? modelContext.fetch(sessionDescriptor)) ?? []
+        let activeSessions = sessions.map {
+            SessionSummary(
+                sessionId: $0.sessionId,
+                projectName: $0.projectName,
+                startTime: $0.startTime,
+                lastTime: $0.lastTime,
+                totalTokens: $0.totalTokens
+            )
+        }
+
+        return OverviewSnapshot(
+            todayTokens: todayTokens,
+            weekTokens: weekTokens,
+            monthTokens: monthTokens,
+            heatmapData: heatmapData,
+            hourlyTokens: hourlyTokens,
+            todayProjects: todayProjectTotals.map { ProjectSummary(name: $0.key, tokens: $0.value) },
+            weekProjects: weekProjectTotals.map { ProjectSummary(name: $0.key, tokens: $0.value) },
+            monthProjects: monthProjectTotals.map { ProjectSummary(name: $0.key, tokens: $0.value) },
+            activeSessions: activeSessions,
+            hasAnyData: !dailies.isEmpty
+        )
+    }
+
+    /// Hourly tokens for a specific day — used when the user selects a date
+    /// in the heatmap.
+    func loadHourlyTokens(for date: Date) -> [Int] {
+        let day = Calendar.current.startOfDay(for: date)
+        let descriptor = FetchDescriptor<HourlyUsage>(
+            predicate: #Predicate { $0.date == day }
+        )
+        let entries = (try? modelContext.fetch(descriptor)) ?? []
+        var buckets = Array(repeating: 0, count: 24)
+        for entry in entries where entry.hour >= 0 && entry.hour < 24 {
+            buckets[entry.hour] += entry.tokens
+        }
+        return buckets
+    }
+
+    /// Project breakdown for a specific day.
+    func loadProjects(for date: Date) -> [ProjectSummary] {
+        let day = Calendar.current.startOfDay(for: date)
+        let descriptor = FetchDescriptor<DailyUsage>(
+            predicate: #Predicate { $0.date == day }
+        )
+        let dailies = (try? modelContext.fetch(descriptor)) ?? []
+        var totals: [String: Int] = [:]
+        for daily in dailies {
+            for project in daily.projectBreakdowns {
+                totals[project.projectName, default: 0] += project.tokens
+            }
+        }
+        return totals.map { ProjectSummary(name: $0.key, tokens: $0.value) }
+    }
+}

--- a/TokenGarden/Services/ProfileManager.swift
+++ b/TokenGarden/Services/ProfileManager.swift
@@ -185,15 +185,14 @@ class ProfileManager: ObservableObject {
 
         let creds = profile.credentialsJSON
         let profileName = profile.name
-        DispatchQueue.global(qos: .utility).async { [weak self] in
+        Task.detached(priority: .utility) { [weak self] in
             let token = CredentialsManager.oauthToken(from: creds)
                 ?? CredentialsManager.currentOAuthToken()
             guard let token else { return }
-            let limits = CredentialsManager.fetchUsageLimits(oauthToken: token)
-            DispatchQueue.main.async {
-                if let limits {
-                    self?.usageLimitsCache[profileName] = limits
-                }
+            let limits = await CredentialsManager.fetchUsageLimits(oauthToken: token)
+            guard let limits else { return }
+            await MainActor.run {
+                self?.usageLimitsCache[profileName] = limits
             }
         }
     }
@@ -238,41 +237,33 @@ class ProfileManager: ObservableObject {
         let activeCredentials = activeProfile?.credentialsJSON
         let credsMgr = credentialsManager
 
-        DispatchQueue.global(qos: .utility).async { [weak self] in
-            for (_, credentials) in credentialPairs {
-                guard credsMgr.writeCredentials(credentials) else { continue }
-
-                let process = Process()
-                process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-                process.arguments = ["claude", "--print-access-token"]
-                process.standardOutput = FileHandle.nullDevice
-                process.standardError = FileHandle.nullDevice
-
-                do {
-                    try process.run()
-                    process.waitUntilExit()
-                } catch {
-                    continue
+        Task.detached(priority: .utility) { [weak self] in
+            // Always restore active credentials on exit, even if any step fails.
+            defer {
+                if let activeCredentials {
+                    _ = credsMgr.writeCredentials(activeCredentials)
                 }
             }
 
-            // Read back refreshed credentials and restore active
-            DispatchQueue.main.async {
+            for (_, credentials) in credentialPairs {
+                guard credsMgr.writeCredentials(credentials) else { continue }
+                _ = await ProcessRunner.run(
+                    executable: "/usr/bin/env",
+                    arguments: ["claude", "--print-access-token"]
+                )
+            }
+
+            // Read back refreshed credentials and restore active on main actor
+            await MainActor.run {
                 guard let self else { return }
-                MainActor.assumeIsolated {
-                    let descriptor = FetchDescriptor<Profile>()
-                    guard let profiles = try? self.modelContext.fetch(descriptor) else { return }
-                    for profile in profiles {
-                        if let refreshed = self.credentialsManager.readCredentials() {
-                            profile.credentialsJSON = refreshed
-                        }
+                let descriptor = FetchDescriptor<Profile>()
+                guard let profiles = try? self.modelContext.fetch(descriptor) else { return }
+                for profile in profiles {
+                    if let refreshed = self.credentialsManager.readCredentials() {
+                        profile.credentialsJSON = refreshed
                     }
-                    // Restore active profile's credentials
-                    if let activeCreds = activeCredentials {
-                        _ = self.credentialsManager.writeCredentials(activeCreds)
-                    }
-                    try? self.modelContext.save()
                 }
+                try? self.modelContext.save()
             }
         }
     }

--- a/TokenGarden/Services/RecordCache.swift
+++ b/TokenGarden/Services/RecordCache.swift
@@ -1,0 +1,154 @@
+import Foundation
+import SwiftData
+
+/// In-memory cache for hot-path entities fetched on every `TokenDataStore.record()` call.
+///
+/// Before: 5 SwiftData fetches per event (DailyUsage, HourlyUsage, ProjectUsage search,
+/// ProfileTokenUsage, SessionUsage). During backfill of thousands of events this caused
+/// severe main-thread hangs.
+///
+/// After: cache holds references for the common hot path (same day/hour/session/profile).
+/// Only the first event for a new key triggers a fetch-or-insert.
+///
+/// Cache invalidation:
+/// - Daily/hourly/profile-token caches evict entries on calendar day change.
+/// - Hourly cache additionally evicts stale hours when the current hour advances.
+/// - Session cache is bounded by the number of active sessions during a run.
+@MainActor
+final class RecordCache {
+    private var dailyUsageCache: [Date: DailyUsage] = [:]
+    private var hourlyUsageCache: [HourKey: HourlyUsage] = [:]
+    private var sessionCache: [String: SessionUsage] = [:]
+    private var profileTokenCache: [ProfileKey: ProfileTokenUsage] = [:]
+
+    private var currentDay: Date = .distantPast
+
+    private struct HourKey: Hashable {
+        let date: Date
+        let hour: Int
+    }
+
+    private struct ProfileKey: Hashable {
+        let profileName: String
+        let date: Date
+    }
+
+    /// Call at the top of every `record()` to drop stale entries when the day rolls over.
+    func invalidateIfNeeded(for timestamp: Date) {
+        let day = Calendar.current.startOfDay(for: timestamp)
+        if day != currentDay {
+            dailyUsageCache.removeAll(keepingCapacity: true)
+            hourlyUsageCache.removeAll(keepingCapacity: true)
+            profileTokenCache.removeAll(keepingCapacity: true)
+            currentDay = day
+        }
+    }
+
+    /// Fully clears the cache. Call when the underlying ModelContext is reset.
+    func clear() {
+        dailyUsageCache.removeAll(keepingCapacity: true)
+        hourlyUsageCache.removeAll(keepingCapacity: true)
+        sessionCache.removeAll(keepingCapacity: true)
+        profileTokenCache.removeAll(keepingCapacity: true)
+        currentDay = .distantPast
+    }
+
+    // MARK: - DailyUsage
+
+    func getOrCreateDaily(day: Date, in context: ModelContext) -> DailyUsage {
+        if let cached = dailyUsageCache[day] {
+            return cached
+        }
+        let descriptor = FetchDescriptor<DailyUsage>(
+            predicate: #Predicate { $0.date == day }
+        )
+        let fetched = (try? context.fetch(descriptor).first)
+        let daily: DailyUsage
+        if let fetched {
+            daily = fetched
+        } else {
+            daily = DailyUsage(date: day)
+            context.insert(daily)
+        }
+        dailyUsageCache[day] = daily
+        return daily
+    }
+
+    // MARK: - HourlyUsage
+
+    func getOrCreateHourly(day: Date, hour: Int, in context: ModelContext) -> HourlyUsage {
+        let key = HourKey(date: day, hour: hour)
+        if let cached = hourlyUsageCache[key] {
+            return cached
+        }
+        let descriptor = FetchDescriptor<HourlyUsage>(
+            predicate: #Predicate { $0.date == day && $0.hour == hour }
+        )
+        let fetched = (try? context.fetch(descriptor).first)
+        let hourly: HourlyUsage
+        if let fetched {
+            hourly = fetched
+        } else {
+            hourly = HourlyUsage(date: day, hour: hour, tokens: 0)
+            context.insert(hourly)
+        }
+        hourlyUsageCache[key] = hourly
+        return hourly
+    }
+
+    // MARK: - SessionUsage
+
+    func getOrCreateSession(
+        sessionId: String,
+        projectName: String,
+        timestamp: Date,
+        in context: ModelContext
+    ) -> SessionUsage {
+        if let cached = sessionCache[sessionId] {
+            return cached
+        }
+        let descriptor = FetchDescriptor<SessionUsage>(
+            predicate: #Predicate { $0.sessionId == sessionId }
+        )
+        let fetched = (try? context.fetch(descriptor).first)
+        let session: SessionUsage
+        if let fetched {
+            session = fetched
+        } else {
+            session = SessionUsage(
+                sessionId: sessionId,
+                projectName: projectName,
+                startTime: timestamp
+            )
+            context.insert(session)
+        }
+        sessionCache[sessionId] = session
+        return session
+    }
+
+    // MARK: - ProfileTokenUsage
+
+    func getOrCreateProfileToken(
+        profileName: String,
+        day: Date,
+        in context: ModelContext
+    ) -> ProfileTokenUsage {
+        let key = ProfileKey(profileName: profileName, date: day)
+        if let cached = profileTokenCache[key] {
+            return cached
+        }
+        let descriptor = FetchDescriptor<ProfileTokenUsage>(
+            predicate: #Predicate { $0.profileName == profileName && $0.date == day }
+        )
+        let fetched = (try? context.fetch(descriptor).first)
+        let usage: ProfileTokenUsage
+        if let fetched {
+            usage = fetched
+        } else {
+            usage = ProfileTokenUsage(profileName: profileName, date: day, tokens: 0)
+            context.insert(usage)
+        }
+        profileTokenCache[key] = usage
+        return usage
+    }
+}

--- a/TokenGarden/Services/TokenDataStore.swift
+++ b/TokenGarden/Services/TokenDataStore.swift
@@ -5,6 +5,7 @@ import SwiftData
 class TokenDataStore: ObservableObject {
     private let modelContainer: ModelContainer
     private let modelContext: ModelContext
+    private let cache = RecordCache()
     private var pendingSaveCount = 0
     var activeProfileName: String?
     private static let saveInterval = 10
@@ -15,19 +16,10 @@ class TokenDataStore: ObservableObject {
     }
 
     func record(_ event: TokenEvent) {
+        cache.invalidateIfNeeded(for: event.timestamp)
+
         let day = Calendar.current.startOfDay(for: event.timestamp)
-
-        let descriptor = FetchDescriptor<DailyUsage>(
-            predicate: #Predicate { $0.date == day }
-        )
-
-        let daily: DailyUsage
-        if let existing = try? modelContext.fetch(descriptor).first {
-            daily = existing
-        } else {
-            daily = DailyUsage(date: day)
-            modelContext.insert(daily)
-        }
+        let daily = cache.getOrCreateDaily(day: day, in: modelContext)
 
         daily.inputTokens += event.inputTokens
         daily.outputTokens += event.outputTokens
@@ -36,16 +28,10 @@ class TokenDataStore: ObservableObject {
 
         // Hourly bucket
         let hour = Calendar.current.component(.hour, from: event.timestamp)
-        let hourlyDescriptor = FetchDescriptor<HourlyUsage>(
-            predicate: #Predicate { $0.date == day && $0.hour == hour }
-        )
-        if let existing = try? modelContext.fetch(hourlyDescriptor).first {
-            existing.tokens += event.totalTokens
-        } else {
-            let hourly = HourlyUsage(date: day, hour: hour, tokens: event.totalTokens)
-            modelContext.insert(hourly)
-        }
+        let hourly = cache.getOrCreateHourly(day: day, hour: hour, in: modelContext)
+        hourly.tokens += event.totalTokens
 
+        // Project breakdown — in-memory traversal of daily.projectBreakdowns (no fetch)
         if let projectName = event.projectName {
             let profile = activeProfileName
             if let existing = daily.projectBreakdowns.first(where: {
@@ -66,35 +52,24 @@ class TokenDataStore: ObservableObject {
 
         // Profile token tracking
         if let profileName = activeProfileName {
-            let profileDescriptor = FetchDescriptor<ProfileTokenUsage>(
-                predicate: #Predicate { $0.profileName == profileName && $0.date == day }
+            let profileUsage = cache.getOrCreateProfileToken(
+                profileName: profileName,
+                day: day,
+                in: modelContext
             )
-            if let existing = try? modelContext.fetch(profileDescriptor).first {
-                existing.tokens += event.totalTokens
-            } else {
-                let usage = ProfileTokenUsage(profileName: profileName, date: day, tokens: event.totalTokens)
-                modelContext.insert(usage)
-            }
+            profileUsage.tokens += event.totalTokens
         }
 
         // Session tracking
         if let sessionId = event.sessionId {
-            let sessionDescriptor = FetchDescriptor<SessionUsage>(
-                predicate: #Predicate { $0.sessionId == sessionId }
+            let session = cache.getOrCreateSession(
+                sessionId: sessionId,
+                projectName: event.projectName ?? "Unknown",
+                timestamp: event.timestamp,
+                in: modelContext
             )
-            if let session = try? modelContext.fetch(sessionDescriptor).first {
-                session.totalTokens += event.totalTokens
-                session.lastTime = event.timestamp
-            } else {
-                let session = SessionUsage(
-                    sessionId: sessionId,
-                    projectName: event.projectName ?? "Unknown",
-                    startTime: event.timestamp
-                )
-                session.totalTokens = event.totalTokens
-                session.lastTime = event.timestamp
-                modelContext.insert(session)
-            }
+            session.totalTokens += event.totalTokens
+            session.lastTime = event.timestamp
         }
 
         pendingSaveCount += 1
@@ -114,20 +89,30 @@ class TokenDataStore: ObservableObject {
     }
 
     /// Apply active status with pre-fetched project names. Must be called on MainActor.
+    ///
+    /// Algorithm: deactivate all currently-active sessions, then for each active project
+    /// fetch only the single most recent session and mark it active. O(activeProjects)
+    /// fetches with `fetchLimit = 1`, replacing the old O(n²) in-memory scan.
     func applyActiveStatus(activeProjects: Set<String>) {
-        let descriptor = FetchDescriptor<SessionUsage>()
-        guard let sessions = try? modelContext.fetch(descriptor) else { return }
+        // Step 1: deactivate all currently-active sessions
+        let activeDescriptor = FetchDescriptor<SessionUsage>(
+            predicate: #Predicate { $0.isActive == true }
+        )
+        if let currentlyActive = try? modelContext.fetch(activeDescriptor) {
+            for session in currentlyActive {
+                session.isActive = false
+            }
+        }
 
-        for session in sessions {
-            session.isActive = false
-
-            if activeProjects.contains(session.projectName) {
-                let projectSessions = sessions
-                    .filter { $0.projectName == session.projectName }
-                    .sorted { $0.lastTime > $1.lastTime }
-                if projectSessions.first?.sessionId == session.sessionId {
-                    session.isActive = true
-                }
+        // Step 2: for each running project, activate its most recent session
+        for projectName in activeProjects {
+            var descriptor = FetchDescriptor<SessionUsage>(
+                predicate: #Predicate { $0.projectName == projectName },
+                sortBy: [SortDescriptor(\.lastTime, order: .reverse)]
+            )
+            descriptor.fetchLimit = 1
+            if let latest = try? modelContext.fetch(descriptor).first {
+                latest.isActive = true
             }
         }
         try? modelContext.save()
@@ -135,19 +120,13 @@ class TokenDataStore: ObservableObject {
 
     /// Returns project names for running claude processes. Safe to call from any thread.
     /// Single lsof call with all PIDs at once to minimize overhead.
-    nonisolated static func getActiveClaudeProjects() -> Set<String> {
+    nonisolated static func getActiveClaudeProjects() async -> Set<String> {
         // Step 1: get PIDs via ps
-        let psPipe = Pipe()
-        let psProc = Process()
-        psProc.executableURL = URL(fileURLWithPath: "/bin/ps")
-        psProc.arguments = ["-eo", "pid,comm"]
-        psProc.standardOutput = psPipe
-        psProc.standardError = FileHandle.nullDevice
-
-        do { try psProc.run() } catch { return [] }
-        let psData = psPipe.fileHandleForReading.readDataToEndOfFile()
-        psProc.waitUntilExit()
-        guard let psOutput = String(data: psData, encoding: .utf8) else { return [] }
+        let psResult = await ProcessRunner.run(
+            executable: "/bin/ps",
+            arguments: ["-eo", "pid,comm"]
+        )
+        guard let psOutput = psResult.outputString else { return [] }
 
         var pids: [String] = []
         for line in psOutput.components(separatedBy: "\n") {
@@ -160,17 +139,11 @@ class TokenDataStore: ObservableObject {
         guard !pids.isEmpty else { return [] }
 
         // Step 2: single lsof call with all PIDs
-        let pipe = Pipe()
-        let proc = Process()
-        proc.executableURL = URL(fileURLWithPath: "/usr/sbin/lsof")
-        proc.arguments = ["-a", "-d", "cwd", "-p", pids.joined(separator: ",")]
-        proc.standardOutput = pipe
-        proc.standardError = FileHandle.nullDevice
-
-        do { try proc.run() } catch { return [] }
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        proc.waitUntilExit()
-        guard let output = String(data: data, encoding: .utf8) else { return [] }
+        let lsofResult = await ProcessRunner.run(
+            executable: "/usr/sbin/lsof",
+            arguments: ["-a", "-d", "cwd", "-p", pids.joined(separator: ",")]
+        )
+        guard let output = lsofResult.outputString else { return [] }
 
         var projects = Set<String>()
         for line in output.components(separatedBy: "\n") {
@@ -200,6 +173,23 @@ class TokenDataStore: ObservableObject {
             sortBy: [SortDescriptor(\.date)]
         )
         return (try? modelContext.fetch(descriptor)) ?? []
+    }
+
+    /// Returns 24 hourly token totals for a given day, read from HourlyUsage rows.
+    /// Replaces the view's `@Query var allHourlyUsages` which loaded the entire table.
+    func fetchHourlyUsageBuckets(for date: Date) -> [Int] {
+        let day = Calendar.current.startOfDay(for: date)
+        let descriptor = FetchDescriptor<HourlyUsage>(
+            predicate: #Predicate { $0.date == day }
+        )
+        guard let entries = try? modelContext.fetch(descriptor) else {
+            return Array(repeating: 0, count: 24)
+        }
+        var buckets = Array(repeating: 0, count: 24)
+        for entry in entries where entry.hour >= 0 && entry.hour < 24 {
+            buckets[entry.hour] += entry.tokens
+        }
+        return buckets
     }
 
     /// Returns 24 hourly token totals for a given day, computed from SessionUsage timestamps

--- a/TokenGarden/Utilities/DebouncedPersistence.swift
+++ b/TokenGarden/Utilities/DebouncedPersistence.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Debounces UserDefaults writes so rapid updates collapse into a single write.
+/// Used by LogWatcher for `saveOffsets()` which was being called on every FSEvent.
+@MainActor
+final class DebouncedPersistence {
+    private let key: String
+    private let delay: TimeInterval
+    private var pendingValue: Any?
+    private var timer: Timer?
+
+    init(key: String, delay: TimeInterval = 2.0) {
+        self.key = key
+        self.delay = delay
+    }
+
+    /// Schedule a value to be written after `delay` seconds.
+    /// Subsequent calls within that window replace the pending value and reset the timer.
+    func schedule(_ value: Any) {
+        pendingValue = value
+        timer?.invalidate()
+        timer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [weak self] _ in
+            Task { @MainActor in
+                self?.flushNow()
+            }
+        }
+    }
+
+    /// Write the pending value immediately. Called on app stop/terminate.
+    func flushNow() {
+        timer?.invalidate()
+        timer = nil
+        if let value = pendingValue {
+            UserDefaults.standard.set(value, forKey: key)
+            pendingValue = nil
+        }
+    }
+}

--- a/TokenGarden/Utilities/ExpandAnimation.swift
+++ b/TokenGarden/Utilities/ExpandAnimation.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+/// Shared animation timings for expand/collapse sections.
+///
+/// Two-phase sequence:
+/// 1. Container height animates (`containerDuration`)
+/// 2. Content fades in after container is fully expanded (`contentFadeInDuration`)
+///
+/// On collapse the order is reversed and the content disappears instantly so
+/// the container can shrink without clipped text.
+enum ExpandAnimation {
+    /// Duration of the container expand/collapse animation.
+    static let containerDuration: Double = 0.32
+
+    /// Duration of the content fade-in (after expand completes).
+    static let contentFadeInDuration: Double = 0.18
+
+    /// Easing for the container height animation.
+    static let container: Animation = .spring(response: 0.38, dampingFraction: 0.86)
+
+    /// Easing for the content fade-in.
+    static let contentFade: Animation = .easeOut(duration: contentFadeInDuration)
+
+    /// Easing for chevron rotation — follows the container but a touch faster.
+    static let chevron: Animation = .spring(response: 0.32, dampingFraction: 0.82)
+
+    /// Toggle an expand section with the two-phase animation.
+    ///
+    /// - On expand: container animates first, then `showContent` flips on completion.
+    /// - On collapse: `showContent` is cleared instantly, then container animates.
+    static func toggle(
+        isExpanded: Binding<Bool>,
+        showContent: Binding<Bool>
+    ) {
+        if isExpanded.wrappedValue {
+            // Collapse: hide content immediately, then shrink container.
+            showContent.wrappedValue = false
+            withAnimation(container) {
+                isExpanded.wrappedValue = false
+            }
+        } else {
+            // Expand: grow container first, then fade content in on completion.
+            withAnimation(container) {
+                isExpanded.wrappedValue = true
+            } completion: {
+                withAnimation(contentFade) {
+                    showContent.wrappedValue = true
+                }
+            }
+        }
+    }
+}

--- a/TokenGarden/Utilities/ProcessRunner.swift
+++ b/TokenGarden/Utilities/ProcessRunner.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// Common wrapper for `Process` execution used across the app.
+/// Replaces the repeated `Process() + Pipe + waitUntilExit` pattern
+/// in TokenDataStore, CredentialsManager, and ProfileManager.
+enum ProcessRunner {
+    struct Result: Sendable {
+        let output: Data
+        let exitCode: Int32
+
+        var outputString: String? {
+            String(data: output, encoding: .utf8)
+        }
+
+        var succeeded: Bool { exitCode == 0 }
+    }
+
+    /// Synchronous execution. Blocks the calling thread until the process exits.
+    /// Use only from background contexts — never from the main thread.
+    nonisolated static func runSync(
+        executable: String,
+        arguments: [String],
+        environment: [String: String]? = nil
+    ) -> Result {
+        let pipe = Pipe()
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+        if let environment {
+            process.environment = environment
+        }
+
+        do {
+            try process.run()
+        } catch {
+            return Result(output: Data(), exitCode: -1)
+        }
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        return Result(output: data, exitCode: process.terminationStatus)
+    }
+
+    /// Async execution via `terminationHandler`. Does not block any thread.
+    nonisolated static func run(
+        executable: String,
+        arguments: [String],
+        environment: [String: String]? = nil
+    ) async -> Result {
+        await withCheckedContinuation { continuation in
+            let pipe = Pipe()
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: executable)
+            process.arguments = arguments
+            process.standardOutput = pipe
+            process.standardError = FileHandle.nullDevice
+            if let environment {
+                process.environment = environment
+            }
+
+            process.terminationHandler = { proc in
+                let data = pipe.fileHandleForReading.readDataToEndOfFile()
+                continuation.resume(
+                    returning: Result(output: data, exitCode: proc.terminationStatus)
+                )
+            }
+
+            do {
+                try process.run()
+            } catch {
+                continuation.resume(returning: Result(output: Data(), exitCode: -1))
+            }
+        }
+    }
+}

--- a/TokenGarden/ViewModels/OverviewViewModel.swift
+++ b/TokenGarden/ViewModels/OverviewViewModel.swift
@@ -1,0 +1,113 @@
+import Foundation
+import Observation
+import SwiftData
+
+/// Main-actor @Observable view model that owns all Overview tab data.
+///
+/// The view reads `snapshot` (plus optional selected-date state) directly.
+/// All fetching is delegated to `OverviewRepository` which runs on a
+/// background actor, so the view never blocks on DB I/O.
+///
+/// Optimistic rendering: after the first load completes, subsequent
+/// refreshes keep `isInitialLoading = false` and update the snapshot in
+/// place. Stale data is visible during refresh instead of flashing skeletons.
+@MainActor
+@Observable
+final class OverviewViewModel {
+    /// Latest data, or `.empty` until the first load completes.
+    private(set) var snapshot: OverviewSnapshot = .empty
+
+    /// True while the very first load is in flight. After that it stays
+    /// false even during background refreshes.
+    private(set) var isInitialLoading: Bool = true
+
+    /// Currently selected heatmap cell, if any. `didSet` fans out to
+    /// `loadSelectedDateData` so the view never has to orchestrate fetches.
+    var selectedDate: Date? = nil {
+        didSet {
+            guard oldValue != selectedDate else { return }
+            loadSelectedDateData()
+        }
+    }
+
+    /// Hourly tokens for the day the user is currently viewing
+    /// (today by default, or the selected date).
+    private(set) var activeHourlyTokens: [Int] = Array(repeating: 0, count: 24)
+
+    /// Project breakdown for a selected day, or nil when no day is selected.
+    private(set) var selectedDayProjects: [ProjectSummary]? = nil
+
+    private let repository: OverviewRepository
+    private var loadTask: Task<Void, Never>?
+    private var debounceTask: Task<Void, Never>?
+    private var selectedDateTask: Task<Void, Never>?
+
+    init(modelContainer: ModelContainer) {
+        self.repository = OverviewRepository(modelContainer: modelContainer)
+    }
+
+    /// Start the initial background load. Call once from AppDelegate at
+    /// app launch — well before the user clicks the menu bar.
+    func start() {
+        refresh()
+    }
+
+    /// Reload the whole snapshot from the repository. Safe to call often
+    /// — earlier tasks are cancelled.
+    func refresh() {
+        loadTask?.cancel()
+        loadTask = Task { [weak self] in
+            guard let self else { return }
+            let new = await self.repository.loadSnapshot()
+            if Task.isCancelled { return }
+            self.snapshot = new
+            // Only reset active hourly if no day is currently selected,
+            // otherwise we'd stomp the user's selection.
+            if self.selectedDate == nil {
+                self.activeHourlyTokens = new.hourlyTokens
+            }
+            self.isInitialLoading = false
+        }
+    }
+
+    /// Notify that a live token event arrived. Debounced to avoid
+    /// refreshing on every keystroke worth of activity.
+    func onTokenEvent() {
+        debounceTask?.cancel()
+        debounceTask = Task { [weak self] in
+            try? await Task.sleep(for: .milliseconds(500))
+            if Task.isCancelled { return }
+            self?.refresh()
+        }
+    }
+
+    /// Wait for any in-flight load / selected-date-load tasks to finish.
+    ///
+    /// Intended for tests that need deterministic state after triggering
+    /// `start()`, `refresh()`, or `selectedDate = ...`. Cheap to call in
+    /// production but rarely needed there.
+    func awaitPendingTasks() async {
+        if let t = loadTask { await t.value }
+        if let t = selectedDateTask { await t.value }
+    }
+
+    private func loadSelectedDateData() {
+        selectedDateTask?.cancel()
+        guard let date = selectedDate else {
+            // Reset to today's view.
+            activeHourlyTokens = snapshot.hourlyTokens
+            selectedDayProjects = nil
+            return
+        }
+        selectedDateTask = Task { [weak self] in
+            guard let self else { return }
+            async let hourly = self.repository.loadHourlyTokens(for: date)
+            async let projects = self.repository.loadProjects(for: date)
+            let h = await hourly
+            let p = await projects
+            if Task.isCancelled { return }
+            self.activeHourlyTokens = h
+            self.selectedDayProjects = p
+        }
+    }
+}

--- a/TokenGarden/Views/AccountsTabView.swift
+++ b/TokenGarden/Views/AccountsTabView.swift
@@ -101,6 +101,7 @@ private struct AccountStatsView: View {
     @Query private var allProfileUsages: [ProfileTokenUsage]
     @Query private var allProjectUsages: [ProjectUsage]
     @State private var isExpanded = false
+    @State private var showContent = false
 
     private var calendar: Calendar { Calendar.current }
 
@@ -156,14 +157,23 @@ private struct AccountStatsView: View {
                         .font(.system(size: 8))
                         .foregroundStyle(.tertiary)
                         .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                        .animation(ExpandAnimation.chevron, value: isExpanded)
                 }
                 .contentShape(Rectangle())
-                .onTapGesture { isExpanded.toggle() }
+                .onTapGesture {
+                    ExpandAnimation.toggle(
+                        isExpanded: $isExpanded,
+                        showContent: $showContent
+                    )
+                }
 
                 if isExpanded {
-                    ForEach(profileNames, id: \.self) { profile in
-                        accountCard(profile)
+                    VStack(alignment: .leading, spacing: 6) {
+                        ForEach(profileNames, id: \.self) { profile in
+                            accountCard(profile)
+                        }
                     }
+                    .opacity(showContent ? 1 : 0)
                 }
             }
             .padding(8)
@@ -241,6 +251,7 @@ private struct AccountDailyChartView: View {
     @Query private var allProfileUsages: [ProfileTokenUsage]
     @Query private var allProfiles: [Profile]
     @State private var isExpanded = false
+    @State private var showContent = false
     @State private var hoveredDay: Int?
 
     private let dayCount = 28
@@ -309,14 +320,23 @@ private struct AccountDailyChartView: View {
                         .font(.system(size: 8))
                         .foregroundStyle(.tertiary)
                         .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                        .animation(ExpandAnimation.chevron, value: isExpanded)
                 }
                 .contentShape(Rectangle())
-                .onTapGesture { isExpanded.toggle() }
+                .onTapGesture {
+                    ExpandAnimation.toggle(
+                        isExpanded: $isExpanded,
+                        showContent: $showContent
+                    )
+                }
 
                 if isExpanded {
-                    ForEach(profileNames, id: \.self) { profile in
-                        profileChart(profile, color: colorForProfile(profile))
+                    VStack(alignment: .leading, spacing: 6) {
+                        ForEach(profileNames, id: \.self) { profile in
+                            profileChart(profile, color: colorForProfile(profile))
+                        }
                     }
+                    .opacity(showContent ? 1 : 0)
                 }
             }
             .padding(8)

--- a/TokenGarden/Views/AccountsTabView.swift
+++ b/TokenGarden/Views/AccountsTabView.swift
@@ -245,6 +245,15 @@ private struct AccountDailyChartView: View {
 
     private let dayCount = 28
 
+    init() {
+        let cutoff = Calendar.current.startOfDay(
+            for: Calendar.current.date(byAdding: .day, value: -28, to: Date()) ?? Date()
+        )
+        _allProfileUsages = Query(
+            filter: #Predicate<ProfileTokenUsage> { $0.date >= cutoff }
+        )
+    }
+
     private var profileNames: [String] {
         Array(Set(allProfileUsages.map(\.profileName))).sorted()
     }

--- a/TokenGarden/Views/HeatmapView.swift
+++ b/TokenGarden/Views/HeatmapView.swift
@@ -47,6 +47,14 @@ struct HeatmapView: View {
     let dailyUsages: [(date: Date, tokens: Int)]
     @Binding var selectedDate: Date?
     @State private var range: HeatmapRange = .default
+    @State private var cachedGridData: [GridCell] = []
+    @State private var cachedCacheKey: GridCacheKey = GridCacheKey(columns: 0, usageCount: 0, totalTokens: 0)
+
+    private struct GridCacheKey: Equatable {
+        let columns: Int
+        let usageCount: Int
+        let totalTokens: Int
+    }
 
     private let rows = 7
     private let cellSize: CGFloat = 18
@@ -62,9 +70,19 @@ struct HeatmapView: View {
 
     private var isYearView: Bool { range == .year }
 
+    private var currentCacheKey: GridCacheKey {
+        GridCacheKey(
+            columns: range.columns,
+            usageCount: dailyUsages.count,
+            totalTokens: dailyUsages.reduce(0) { $0 + $1.tokens }
+        )
+    }
+
     var body: some View {
         let columns = range.columns
-        let gridData = buildGrid(columns: columns)
+        let gridData = cachedGridData.isEmpty || cachedCacheKey != currentCacheKey
+            ? buildGrid(columns: columns)
+            : cachedGridData
 
         VStack(alignment: .leading, spacing: 0) {
             // Range picker
@@ -94,6 +112,17 @@ struct HeatmapView: View {
             } else {
                 fixedGrid(gridData: gridData, columns: columns)
             }
+        }
+        .onAppear { updateGridCache() }
+        .onChange(of: range) { _, _ in updateGridCache() }
+        .onChange(of: currentCacheKey) { _, _ in updateGridCache() }
+    }
+
+    private func updateGridCache() {
+        let key = currentCacheKey
+        if key != cachedCacheKey {
+            cachedGridData = buildGrid(columns: key.columns)
+            cachedCacheKey = key
         }
     }
 

--- a/TokenGarden/Views/HourlyChartView.swift
+++ b/TokenGarden/Views/HourlyChartView.swift
@@ -4,6 +4,7 @@ struct HourlyChartView: View {
     let hourlyTokens: [Int]
     var isToday: Bool = true
     @State private var isExpanded = false
+    @State private var showContent = false
     @State private var hoveredHour: Int?
 
     @AppStorage("heatmapTheme") private var themeName = HeatmapTheme.green.rawValue
@@ -35,9 +36,15 @@ struct HourlyChartView: View {
                     .font(.system(size: 8))
                     .foregroundStyle(.tertiary)
                     .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                    .animation(ExpandAnimation.chevron, value: isExpanded)
             }
             .contentShape(Rectangle())
-            .onTapGesture { isExpanded.toggle() }
+            .onTapGesture {
+                ExpandAnimation.toggle(
+                    isExpanded: $isExpanded,
+                    showContent: $showContent
+                )
+            }
 
             if isExpanded {
                 VStack(spacing: 4) {
@@ -58,6 +65,7 @@ struct HourlyChartView: View {
                     .font(.system(size: 9))
                     .foregroundStyle(.tertiary)
                 }
+                .opacity(showContent ? 1 : 0)
             }
         }
         .padding(8)

--- a/TokenGarden/Views/PopoverView.swift
+++ b/TokenGarden/Views/PopoverView.swift
@@ -4,92 +4,12 @@ import SwiftData
 struct PopoverView: View {
     @EnvironmentObject var menuBarController: MenuBarController
     @EnvironmentObject var dataStore: TokenDataStore
-    @Query(sort: \DailyUsage.date) private var allUsages: [DailyUsage]
+    @Environment(OverviewViewModel.self) private var vm
+
     enum Tab { case overview, accounts }
     @State private var activeTab: Tab = .overview
     @State private var showSettings = false
     @State private var showProfiles = false
-    @State private var selectedDate: Date?
-    @State private var activeHourlyTokens: [Int] = Array(repeating: 0, count: 24)
-
-    private var todayUsage: DailyUsage? {
-        let today = Calendar.current.startOfDay(for: Date())
-        return allUsages.first { $0.date == today }
-    }
-
-    private var weekTokens: Int {
-        var calendar = Calendar.current
-        calendar.firstWeekday = 2 // Monday
-        let weekStart = calendar.dateComponents([.calendar, .yearForWeekOfYear, .weekOfYear], from: Date()).date!
-        return allUsages
-            .filter { $0.date >= weekStart }
-            .reduce(0) { $0 + $1.totalTokens }
-    }
-
-    private var monthTokens: Int {
-        let calendar = Calendar.current
-        let comps = calendar.dateComponents([.year, .month], from: Date())
-        let monthStart = calendar.date(from: comps)!
-        return allUsages
-            .filter { $0.date >= monthStart }
-            .reduce(0) { $0 + $1.totalTokens }
-    }
-
-    private var heatmapData: [(date: Date, tokens: Int)] {
-        allUsages.map { (date: $0.date, tokens: $0.totalTokens) }
-    }
-
-    private func reloadHourlyTokens() {
-        let target = selectedDate ?? Date()
-        activeHourlyTokens = dataStore.fetchHourlyUsageBuckets(for: target)
-    }
-
-    // MARK: - Project data by time range
-
-    private func projectsForUsages(_ usages: [DailyUsage]) -> [(name: String, tokens: Int)] {
-        var totals: [String: Int] = [:]
-        for usage in usages {
-            for project in usage.projectBreakdowns {
-                totals[project.projectName, default: 0] += project.tokens
-            }
-        }
-        return totals.map { (name: $0.key, tokens: $0.value) }
-    }
-
-    private var todayProjects: [(name: String, tokens: Int)] {
-        let today = Calendar.current.startOfDay(for: Date())
-        return projectsForUsages(allUsages.filter { $0.date == today })
-    }
-
-    private var weekProjects: [(name: String, tokens: Int)] {
-        var calendar = Calendar.current
-        calendar.firstWeekday = 2
-        let weekStart = calendar.dateComponents([.calendar, .yearForWeekOfYear, .weekOfYear], from: Date()).date!
-        return projectsForUsages(allUsages.filter { $0.date >= weekStart })
-    }
-
-    private var monthProjects: [(name: String, tokens: Int)] {
-        let calendar = Calendar.current
-        let comps = calendar.dateComponents([.year, .month], from: Date())
-        let monthStart = calendar.date(from: comps)!
-        return projectsForUsages(allUsages.filter { $0.date >= monthStart })
-    }
-
-    private var selectedDayProjects: [(name: String, tokens: Int)]? {
-        guard let date = selectedDate else { return nil }
-        let day = Calendar.current.startOfDay(for: date)
-        let usages = allUsages.filter { $0.date == day }
-        guard !usages.isEmpty else { return [] }
-        return projectsForUsages(usages)
-    }
-
-    private var selectedDayLabel: String? {
-        guard let date = selectedDate else { return nil }
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US")
-        formatter.dateFormat = "M/d (E)"
-        return formatter.string(from: date)
-    }
 
     @State private var cachedPathState: PathState = .unknown
 
@@ -105,7 +25,10 @@ struct PopoverView: View {
         case .missing: return .noClaudeCode
         case .unreadable: return .noPermission
         case .ok, .unknown:
-            return allUsages.isEmpty ? .noData : nil
+            // While the initial load is in flight we show a skeleton instead
+            // of an "empty" message.
+            if vm.isInitialLoading { return nil }
+            return vm.snapshot.hasAnyData ? nil : .noData
         }
     }
 
@@ -121,7 +44,17 @@ struct PopoverView: View {
         }
     }
 
+    private var selectedDayLabel: String? {
+        guard let date = vm.selectedDate else { return nil }
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US")
+        formatter.dateFormat = "M/d (E)"
+        return formatter.string(from: date)
+    }
+
     var body: some View {
+        @Bindable var vm = vm
+
         VStack(spacing: 0) {
             HStack {
                 if showSettings || showProfiles {
@@ -181,58 +114,14 @@ struct PopoverView: View {
             } else if showProfiles {
                 ProfileListView()
             } else if activeTab == .accounts {
-                AccountsTabView()
-                    .transition(.identity)
-            } else {
-                VStack(alignment: .leading, spacing: 12) {
-                    HeatmapView(dailyUsages: heatmapData, selectedDate: $selectedDate)
-                        .padding(.horizontal, 12)
-                        .padding(.top, 8)
-
-                    if let date = selectedDate,
-                       let usage = allUsages.first(where: {
-                           Calendar.current.isDate($0.date, inSameDayAs: date)
-                       }) {
-                        HStack {
-                            Text(selectedDayLabel ?? "")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                            Spacer()
-                            Text(TokenFormatter.format(usage.totalTokens))
-                                .font(.caption.monospacedDigit())
-                                .fontWeight(.medium)
-                        }
-                        .padding(8)
-                        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
-                        .padding(.horizontal, 12)
-                    } else {
-                        StatsView(
-                            todayTokens: todayUsage?.totalTokens ?? 0,
-                            weekTokens: weekTokens,
-                            monthTokens: monthTokens
-                        )
-                        .padding(.horizontal, 12)
-                    }
-
-                    HourlyChartView(
-                        hourlyTokens: activeHourlyTokens,
-                        isToday: selectedDate == nil || Calendar.current.isDateInToday(selectedDate!)
-                    )
-                        .padding(.horizontal, 12)
-
-                    ProjectListView(
-                        todayProjects: todayProjects,
-                        weekProjects: weekProjects,
-                        monthProjects: monthProjects,
-                        selectedDayProjects: selectedDayProjects,
-                        selectedDayLabel: selectedDayLabel
-                    )
-                    .padding(.horizontal, 12)
-
-                    SessionListView()
-                        .padding(.horizontal, 12)
+                ScrollView {
+                    AccountsTabView()
                 }
-                .padding(.bottom, 12)
+                .scrollIndicators(.never)
+                .frame(height: tabContentHeight)
+                .transition(.identity)
+            } else {
+                overviewContent(vm: $vm)
             }
         }
         .frame(width: 320)
@@ -241,13 +130,84 @@ struct PopoverView: View {
         .animation(nil, value: activeTab)
         .onAppear {
             refreshPathState()
-            reloadHourlyTokens()
         }
-        .onChange(of: selectedDate) { _, _ in
-            reloadHourlyTokens()
+    }
+
+    /// Fixed inner height for the Overview tab. The popover itself stays
+    /// this size regardless of expanded/collapsed section state; overflow
+    /// scrolls inside the ScrollView.
+    private let tabContentHeight: CGFloat = 520
+
+    @ViewBuilder
+    private func overviewContent(vm: Bindable<OverviewViewModel>) -> some View {
+        Group {
+            if vm.wrappedValue.isInitialLoading {
+                OverviewSkeleton()
+                    .frame(maxWidth: .infinity, alignment: .top)
+                    .transition(.opacity)
+            } else {
+                let snapshot = vm.wrappedValue.snapshot
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 12) {
+                        HeatmapView(
+                            dailyUsages: snapshot.heatmapData.map { (date: $0.date, tokens: $0.tokens) },
+                            selectedDate: vm.selectedDate
+                        )
+                        .padding(.horizontal, 12)
+                        .padding(.top, 8)
+
+                        if let date = vm.wrappedValue.selectedDate,
+                           let cell = snapshot.heatmapData.first(where: {
+                               Calendar.current.isDate($0.date, inSameDayAs: date)
+                           }) {
+                            HStack {
+                                Text(selectedDayLabel ?? "")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                Spacer()
+                                Text(TokenFormatter.format(cell.tokens))
+                                    .font(.caption.monospacedDigit())
+                                    .fontWeight(.medium)
+                            }
+                            .padding(8)
+                            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
+                            .padding(.horizontal, 12)
+                        } else {
+                            StatsView(
+                                todayTokens: snapshot.todayTokens,
+                                weekTokens: snapshot.weekTokens,
+                                monthTokens: snapshot.monthTokens
+                            )
+                            .padding(.horizontal, 12)
+                        }
+
+                        HourlyChartView(
+                            hourlyTokens: vm.wrappedValue.activeHourlyTokens,
+                            isToday: vm.wrappedValue.selectedDate == nil
+                                || Calendar.current.isDateInToday(vm.wrappedValue.selectedDate!)
+                        )
+                        .padding(.horizontal, 12)
+
+                        ProjectListView(
+                            todayProjects: snapshot.todayProjects.map { (name: $0.name, tokens: $0.tokens) },
+                            weekProjects: snapshot.weekProjects.map { (name: $0.name, tokens: $0.tokens) },
+                            monthProjects: snapshot.monthProjects.map { (name: $0.name, tokens: $0.tokens) },
+                            selectedDayProjects: vm.wrappedValue.selectedDayProjects?.map {
+                                (name: $0.name, tokens: $0.tokens)
+                            },
+                            selectedDayLabel: selectedDayLabel
+                        )
+                        .padding(.horizontal, 12)
+
+                        SessionListView(sessions: snapshot.activeSessions)
+                            .padding(.horizontal, 12)
+                    }
+                    .padding(.bottom, 12)
+                }
+                .scrollIndicators(.never)
+                .transition(.opacity)
+            }
         }
-        .onChange(of: allUsages.count) { _, _ in
-            reloadHourlyTokens()
-        }
+        .frame(height: tabContentHeight)
     }
 }

--- a/TokenGarden/Views/PopoverView.swift
+++ b/TokenGarden/Views/PopoverView.swift
@@ -3,12 +3,14 @@ import SwiftData
 
 struct PopoverView: View {
     @EnvironmentObject var menuBarController: MenuBarController
+    @EnvironmentObject var dataStore: TokenDataStore
     @Query(sort: \DailyUsage.date) private var allUsages: [DailyUsage]
     enum Tab { case overview, accounts }
     @State private var activeTab: Tab = .overview
     @State private var showSettings = false
     @State private var showProfiles = false
     @State private var selectedDate: Date?
+    @State private var activeHourlyTokens: [Int] = Array(repeating: 0, count: 24)
 
     private var todayUsage: DailyUsage? {
         let today = Calendar.current.startOfDay(for: Date())
@@ -37,20 +39,9 @@ struct PopoverView: View {
         allUsages.map { (date: $0.date, tokens: $0.totalTokens) }
     }
 
-    @Query private var allHourlyUsages: [HourlyUsage]
-
-    private var activeHourlyTokens: [Int] {
-        let cal = Calendar.current
-        let targetDay = cal.startOfDay(for: selectedDate ?? Date())
-
-        let dayEntries = allHourlyUsages.filter { $0.date == targetDay }
-
-        var buckets = Array(repeating: 0, count: 24)
-        for entry in dayEntries {
-            guard entry.hour >= 0 && entry.hour < 24 else { continue }
-            buckets[entry.hour] += entry.tokens
-        }
-        return buckets
+    private func reloadHourlyTokens() {
+        let target = selectedDate ?? Date()
+        activeHourlyTokens = dataStore.fetchHourlyUsageBuckets(for: target)
     }
 
     // MARK: - Project data by time range
@@ -100,20 +91,34 @@ struct PopoverView: View {
         return formatter.string(from: date)
     }
 
+    @State private var cachedPathState: PathState = .unknown
+
+    private enum PathState {
+        case unknown
+        case missing
+        case unreadable
+        case ok
+    }
+
     private var emptyStateReason: EmptyStateReason? {
+        switch cachedPathState {
+        case .missing: return .noClaudeCode
+        case .unreadable: return .noPermission
+        case .ok, .unknown:
+            return allUsages.isEmpty ? .noData : nil
+        }
+    }
+
+    private func refreshPathState() {
         let logPath = UserDefaults.standard.string(forKey: "logPath") ?? "~/.claude/"
         let expandedPath = NSString(string: logPath).expandingTildeInPath
-
         if !FileManager.default.fileExists(atPath: expandedPath) {
-            return .noClaudeCode
+            cachedPathState = .missing
+        } else if !FileManager.default.isReadableFile(atPath: expandedPath) {
+            cachedPathState = .unreadable
+        } else {
+            cachedPathState = .ok
         }
-        if !FileManager.default.isReadableFile(atPath: expandedPath) {
-            return .noPermission
-        }
-        if allUsages.isEmpty {
-            return .noData
-        }
-        return nil
     }
 
     var body: some View {
@@ -234,5 +239,15 @@ struct PopoverView: View {
         .animation(nil, value: showSettings)
         .animation(nil, value: showProfiles)
         .animation(nil, value: activeTab)
+        .onAppear {
+            refreshPathState()
+            reloadHourlyTokens()
+        }
+        .onChange(of: selectedDate) { _, _ in
+            reloadHourlyTokens()
+        }
+        .onChange(of: allUsages.count) { _, _ in
+            reloadHourlyTokens()
+        }
     }
 }

--- a/TokenGarden/Views/ProjectListView.swift
+++ b/TokenGarden/Views/ProjectListView.swift
@@ -14,6 +14,7 @@ struct ProjectListView: View {
     var selectedDayLabel: String?
     @State private var selectedRange: ProjectTimeRange = .week
     @State private var isExpanded = false
+    @State private var showContent = false
 
     private var activeProjects: [(name: String, tokens: Int)] {
         if let selected = selectedDayProjects {
@@ -33,7 +34,12 @@ struct ProjectListView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             // Header
-            Button(action: { isExpanded.toggle() }) {
+            Button(action: {
+                ExpandAnimation.toggle(
+                    isExpanded: $isExpanded,
+                    showContent: $showContent
+                )
+            }) {
                 HStack {
                     Label(selectedDayLabel ?? "Projects", systemImage: "folder.fill")
                         .font(.caption)
@@ -44,7 +50,7 @@ struct ProjectListView: View {
                     Spacer()
 
                     if selectedDayProjects == nil && isExpanded {
-                        // Time range picker
+                        // Time range picker — fade in with content
                         HStack(spacing: 2) {
                             ForEach(ProjectTimeRange.allCases, id: \.self) { range in
                                 Text(range.rawValue)
@@ -63,52 +69,57 @@ struct ProjectListView: View {
                                     }
                             }
                         }
+                        .opacity(showContent ? 1 : 0)
                     }
 
                     Image(systemName: "chevron.right")
                         .font(.caption2)
                         .foregroundStyle(.tertiary)
                         .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                        .animation(ExpandAnimation.chevron, value: isExpanded)
                 }
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
 
             if isExpanded {
-                if activeProjects.isEmpty {
-                    Text("No projects")
-                        .font(.caption)
-                        .foregroundStyle(.tertiary)
-                        .padding(.vertical, 4)
-                } else {
-                    let items = activeProjects.sorted(by: { $0.tokens > $1.tokens })
-                    let content = VStack(spacing: 0) {
-                        ForEach(items, id: \.name) { project in
-                            HStack {
-                                Text(project.name)
-                                    .font(.caption)
-                                    .lineLimit(1)
-                                Spacer()
-                                Text(TokenFormatter.format(project.tokens))
-                                    .font(.caption2.monospacedDigit())
-                                    .foregroundStyle(.secondary)
-                                let pct = totalTokens > 0 ? Int(Double(project.tokens) / Double(totalTokens) * 100) : 0
-                                Text("\(pct)%")
-                                    .font(.caption.monospacedDigit())
-                                    .foregroundStyle(.secondary)
-                                    .frame(width: 30, alignment: .trailing)
+                Group {
+                    if activeProjects.isEmpty {
+                        Text("No projects")
+                            .font(.caption)
+                            .foregroundStyle(.tertiary)
+                            .padding(.vertical, 4)
+                    } else {
+                        let items = activeProjects.sorted(by: { $0.tokens > $1.tokens })
+                        let content = VStack(spacing: 0) {
+                            ForEach(items, id: \.name) { project in
+                                HStack {
+                                    Text(project.name)
+                                        .font(.caption)
+                                        .lineLimit(1)
+                                    Spacer()
+                                    Text(TokenFormatter.format(project.tokens))
+                                        .font(.caption2.monospacedDigit())
+                                        .foregroundStyle(.secondary)
+                                    let pct = totalTokens > 0 ? Int(Double(project.tokens) / Double(totalTokens) * 100) : 0
+                                    Text("\(pct)%")
+                                        .font(.caption.monospacedDigit())
+                                        .foregroundStyle(.secondary)
+                                        .frame(width: 30, alignment: .trailing)
+                                }
+                                .padding(.vertical, 2)
                             }
-                            .padding(.vertical, 2)
+                        }
+                        if items.count > 10 {
+                            ScrollView { content }
+                                .scrollIndicators(.never)
+                                .frame(maxHeight: 250)
+                        } else {
+                            content
                         }
                     }
-                    if items.count > 10 {
-                        ScrollView { content }
-                            .scrollIndicators(.never)
-                            .frame(maxHeight: 250)
-                    } else {
-                        content
-                    }
                 }
+                .opacity(showContent ? 1 : 0)
             }
         }
         .padding(8)

--- a/TokenGarden/Views/PulseSkeleton.swift
+++ b/TokenGarden/Views/PulseSkeleton.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+/// Pulse-animated skeleton placeholder. Used while data is loading for the
+/// first time — subsequent refreshes show stale data instead so the
+/// skeleton rarely (if ever) appears in normal use.
+struct PulseSkeleton: View {
+    var width: CGFloat? = nil
+    var height: CGFloat = 14
+    var cornerRadius: CGFloat = 4
+
+    @State private var isPulsing = false
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: cornerRadius)
+            .fill(Color.primary.opacity(isPulsing ? 0.06 : 0.14))
+            .frame(width: width, height: height)
+            .onAppear {
+                guard !isPulsing else { return }
+                withAnimation(.easeInOut(duration: 0.9).repeatForever(autoreverses: true)) {
+                    isPulsing = true
+                }
+            }
+    }
+}
+
+/// Skeleton for the whole Overview tab. Rough layout matches the real UI
+/// so the transition to real content doesn't jump.
+struct OverviewSkeleton: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            // Heatmap block
+            VStack(alignment: .leading, spacing: 6) {
+                HStack {
+                    Spacer()
+                    PulseSkeleton(width: 110, height: 14, cornerRadius: 4)
+                }
+                PulseSkeleton(height: 132, cornerRadius: 6)
+            }
+            .padding(.horizontal, 12)
+            .padding(.top, 8)
+
+            // Stats block
+            PulseSkeleton(height: 32, cornerRadius: 8)
+                .padding(.horizontal, 12)
+
+            // Hourly chart block
+            PulseSkeleton(height: 32, cornerRadius: 8)
+                .padding(.horizontal, 12)
+
+            // Projects block
+            PulseSkeleton(height: 32, cornerRadius: 8)
+                .padding(.horizontal, 12)
+
+            // Sessions block
+            PulseSkeleton(height: 32, cornerRadius: 8)
+                .padding(.horizontal, 12)
+        }
+        .padding(.bottom, 12)
+    }
+}

--- a/TokenGarden/Views/SessionListView.swift
+++ b/TokenGarden/Views/SessionListView.swift
@@ -1,23 +1,24 @@
 import SwiftUI
-import SwiftData
 
 struct SessionListView: View {
-    @Query(
-        filter: #Predicate<SessionUsage> { $0.isActive == true },
-        sort: \SessionUsage.lastTime,
-        order: .reverse
-    ) private var activeSessions: [SessionUsage]
+    let sessions: [SessionSummary]
 
     @State private var isExpanded = false
+    @State private var showContent = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
-            Button(action: { isExpanded.toggle() }) {
+            Button(action: {
+                ExpandAnimation.toggle(
+                    isExpanded: $isExpanded,
+                    showContent: $showContent
+                )
+            }) {
                 HStack {
                     Label("Active Sessions", systemImage: "bolt.fill")
                         .font(.caption)
                         .foregroundStyle(.secondary)
-                    Text("\(activeSessions.count)")
+                    Text("\(sessions.count)")
                         .font(.caption2)
                         .foregroundStyle(.tertiary)
                     Spacer()
@@ -25,31 +26,35 @@ struct SessionListView: View {
                         .font(.caption2)
                         .foregroundStyle(.tertiary)
                         .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                        .animation(ExpandAnimation.chevron, value: isExpanded)
                 }
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
 
             if isExpanded {
-                if activeSessions.isEmpty {
-                    Text("No active sessions")
-                        .font(.caption)
-                        .foregroundStyle(.tertiary)
-                        .padding(.vertical, 4)
-                } else {
-                    let content = VStack(spacing: 4) {
-                        ForEach(activeSessions, id: \.sessionId) { session in
-                            SessionRow(session: session)
+                Group {
+                    if sessions.isEmpty {
+                        Text("No active sessions")
+                            .font(.caption)
+                            .foregroundStyle(.tertiary)
+                            .padding(.vertical, 4)
+                    } else {
+                        let content = VStack(spacing: 4) {
+                            ForEach(sessions) { session in
+                                SessionRow(session: session)
+                            }
+                        }
+                        if sessions.count > 10 {
+                            ScrollView { content }
+                                .scrollIndicators(.never)
+                                .frame(maxHeight: 250)
+                        } else {
+                            content
                         }
                     }
-                    if activeSessions.count > 10 {
-                        ScrollView { content }
-                            .scrollIndicators(.never)
-                            .frame(maxHeight: 250)
-                    } else {
-                        content
-                    }
                 }
+                .opacity(showContent ? 1 : 0)
             }
         }
         .padding(8)
@@ -58,7 +63,7 @@ struct SessionListView: View {
 }
 
 private struct SessionRow: View {
-    let session: SessionUsage
+    let session: SessionSummary
 
     private static let timeFormatter: DateFormatter = {
         let f = DateFormatter()

--- a/TokenGarden/Views/StatsView.swift
+++ b/TokenGarden/Views/StatsView.swift
@@ -5,6 +5,7 @@ struct StatsView: View {
     let weekTokens: Int
     let monthTokens: Int
     @State private var isExpanded = false
+    @State private var showContent = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
@@ -22,9 +23,15 @@ struct StatsView: View {
                     .font(.system(size: 8))
                     .foregroundStyle(.tertiary)
                     .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                    .animation(ExpandAnimation.chevron, value: isExpanded)
             }
             .contentShape(Rectangle())
-            .onTapGesture { isExpanded.toggle() }
+            .onTapGesture {
+                ExpandAnimation.toggle(
+                    isExpanded: $isExpanded,
+                    showContent: $showContent
+                )
+            }
 
             if isExpanded {
                 VStack(spacing: 6) {
@@ -32,6 +39,7 @@ struct StatsView: View {
                     statsRow(label: "This Week", value: weekTokens)
                     statsRow(label: "This Month", value: monthTokens)
                 }
+                .opacity(showContent ? 1 : 0)
             }
         }
         .padding(8)

--- a/TokenGardenTests/AppDelegateProfileBackupTests.swift
+++ b/TokenGardenTests/AppDelegateProfileBackupTests.swift
@@ -1,0 +1,118 @@
+import Foundation
+import SQLite3
+import Testing
+@testable import TokenGarden
+
+/// Regression tests for the profile-loss bug triggered by
+/// ModelContainer-init failure on stores whose WAL has uncheckpointed rows.
+///
+/// On 2026-04-10 a crash left the SwiftData store in a state where the
+/// reset path in `AppDelegate.applicationDidFinishLaunching` ran but
+/// `backupProfiles` used `sqlite3_open` without checkpointing the WAL,
+/// returning zero rows even though profiles existed. The reset path then
+/// destroyed the store, silently losing the profiles.
+@Suite("AppDelegate profile backup")
+@MainActor
+struct AppDelegateProfileBackupTests {
+
+    private func makeTempDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TokenGardenTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func makeStoreWithProfileInWAL(
+        in dir: URL,
+        name: String,
+        email: String
+    ) throws -> URL {
+        let storeURL = dir.appendingPathComponent("TokenGarden.store")
+        var db: OpaquePointer?
+        sqlite3_open(storeURL.path, &db)
+        defer { sqlite3_close(db) }
+
+        sqlite3_exec(db, "PRAGMA journal_mode=WAL", nil, nil, nil)
+        sqlite3_exec(db, """
+            CREATE TABLE ZPROFILE (
+                Z_PK INTEGER PRIMARY KEY,
+                ZNAME TEXT,
+                ZEMAIL TEXT,
+                ZPLAN TEXT,
+                ZCREDENTIALSJSON BLOB,
+                ZISACTIVE INTEGER,
+                ZMONTHLYLIMIT INTEGER,
+                ZCOLORNAME TEXT
+            )
+        """, nil, nil, nil)
+        let insert = """
+            INSERT INTO ZPROFILE (ZNAME, ZEMAIL, ZPLAN, ZCREDENTIALSJSON, ZISACTIVE, ZMONTHLYLIMIT, ZCOLORNAME)
+            VALUES ('\(name)', '\(email)', 'max', X'7B7D', 1, 50000000, 'blue')
+        """
+        sqlite3_exec(db, insert, nil, nil, nil)
+        return storeURL
+    }
+
+    @Test("backupProfiles reads rows even when they live only in the WAL")
+    func backupProfilesChecksPointsWAL() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let storeURL = try makeStoreWithProfileInWAL(in: dir, name: "alice", email: "a@example.com")
+        let result = AppDelegate.backupProfiles(from: storeURL)
+
+        #expect(result.didReadDatabase == true)
+        #expect(result.profiles.count == 1)
+        #expect(result.profiles.first?.name == "alice")
+        #expect(result.profiles.first?.email == "a@example.com")
+    }
+
+    @Test("backupProfiles returns didReadDatabase=false when file is missing")
+    func backupProfilesMissingFile() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let missingStore = dir.appendingPathComponent("nope.store")
+        let result = AppDelegate.backupProfiles(from: missingStore)
+
+        #expect(result.didReadDatabase == false)
+        #expect(result.profiles.isEmpty)
+    }
+
+    @Test("backupProfiles returns didReadDatabase=false when ZPROFILE is absent")
+    func backupProfilesSchemaMismatch() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let storeURL = dir.appendingPathComponent("TokenGarden.store")
+        var db: OpaquePointer?
+        sqlite3_open(storeURL.path, &db)
+        sqlite3_exec(db, "CREATE TABLE OTHER (id INTEGER)", nil, nil, nil)
+        sqlite3_close(db)
+
+        let result = AppDelegate.backupProfiles(from: storeURL)
+        #expect(result.didReadDatabase == false)
+        #expect(result.profiles.isEmpty)
+    }
+
+    @Test("archiveStoreFiles renames store + wal + shm instead of deleting")
+    func archiveStoreFilesPreservesData() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let storeName = "TokenGarden.store"
+        for suffix in ["", "-shm", "-wal"] {
+            let path = dir.appendingPathComponent(storeName + suffix)
+            try Data("payload-\(suffix)".utf8).write(to: path)
+        }
+
+        AppDelegate.archiveStoreFiles(in: dir, storeName: storeName)
+
+        let remaining = (try? FileManager.default.contentsOfDirectory(atPath: dir.path)) ?? []
+        #expect(!remaining.contains(storeName))
+        #expect(!remaining.contains(storeName + "-shm"))
+        #expect(!remaining.contains(storeName + "-wal"))
+        #expect(remaining.contains(where: { $0.hasPrefix("\(storeName).corrupted-") }))
+        #expect(remaining.filter { $0.hasPrefix("\(storeName).corrupted-") }.count == 3)
+    }
+}

--- a/TokenGardenTests/HeatmapViewTests.swift
+++ b/TokenGardenTests/HeatmapViewTests.swift
@@ -7,6 +7,8 @@ import Testing
 }
 
 @Test func heatmapLevelQuartiles() {
+    // 7-level scale: zeros stay 0, the max becomes 7, and everything in
+    // between is bucketed by septile.
     let totals = [0, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 0]
     let levels = HeatmapCalculator.calculateLevels(dailyTotals: totals)
 
@@ -14,13 +16,14 @@ import Testing
     #expect(levels[0] == 0)
     #expect(levels[11] == 0)
     #expect(levels[1] >= 1)
-    #expect(levels[10] == 4)
+    #expect(levels[10] == 7)
 }
 
 @Test func heatmapLevelAllSameUsage() {
+    // Every non-zero value equals maxVal → all land in the top bucket (7).
     let totals = [500, 500, 500, 500]
     let levels = HeatmapCalculator.calculateLevels(dailyTotals: totals)
     for level in levels {
-        #expect(level == 4)
+        #expect(level == 7)
     }
 }

--- a/TokenGardenTests/OverviewRepositoryTests.swift
+++ b/TokenGardenTests/OverviewRepositoryTests.swift
@@ -1,0 +1,199 @@
+import Testing
+import SwiftData
+import Foundation
+@testable import TokenGarden
+
+// MARK: - Helpers
+
+@MainActor
+private func makeContainer() throws -> ModelContainer {
+    let config = ModelConfiguration(isStoredInMemoryOnly: true)
+    return try ModelContainer(
+        for: DailyUsage.self,
+        ProjectUsage.self,
+        SessionUsage.self,
+        HourlyUsage.self,
+        configurations: config
+    )
+}
+
+// MARK: - loadSnapshot
+
+@Test @MainActor func loadSnapshot_emptyDB_returnsEmptySnapshot() async throws {
+    let container = try makeContainer()
+    let repository = OverviewRepository(modelContainer: container)
+
+    let snapshot = await repository.loadSnapshot()
+
+    #expect(snapshot.hasAnyData == false)
+    #expect(snapshot.todayTokens == 0)
+    #expect(snapshot.weekTokens == 0)
+    #expect(snapshot.monthTokens == 0)
+    #expect(snapshot.heatmapData.isEmpty)
+    #expect(snapshot.todayProjects.isEmpty)
+    #expect(snapshot.activeSessions.isEmpty)
+    #expect(snapshot.hourlyTokens.count == 24)
+    #expect(snapshot.hourlyTokens.allSatisfy { $0 == 0 })
+}
+
+@Test @MainActor func loadSnapshot_aggregatesTodayTokens() async throws {
+    let container = try makeContainer()
+    let context = ModelContext(container)
+
+    let today = Calendar.current.startOfDay(for: Date())
+    let todayUsage = DailyUsage(date: today)
+    todayUsage.inputTokens = 100
+    todayUsage.outputTokens = 50
+    context.insert(todayUsage)
+
+    // A very old entry — outside week and month windows. Proves the
+    // aggregation windows filter correctly regardless of today's date.
+    let yearAgo = Calendar.current.date(byAdding: .day, value: -365, to: today)!
+    let oldUsage = DailyUsage(date: yearAgo)
+    oldUsage.inputTokens = 999
+    oldUsage.outputTokens = 999
+    context.insert(oldUsage)
+
+    try context.save()
+
+    let repository = OverviewRepository(modelContainer: container)
+    let snapshot = await repository.loadSnapshot()
+
+    #expect(snapshot.todayTokens == 150)
+    #expect(snapshot.weekTokens == 150)   // yearAgo excluded
+    #expect(snapshot.monthTokens == 150)  // yearAgo excluded
+    #expect(snapshot.hasAnyData == true)
+    #expect(snapshot.heatmapData.count == 2)
+}
+
+@Test @MainActor func loadSnapshot_aggregatesProjectBreakdownsForToday() async throws {
+    let container = try makeContainer()
+    let context = ModelContext(container)
+
+    let today = Calendar.current.startOfDay(for: Date())
+    let daily = DailyUsage(date: today)
+    daily.inputTokens = 150
+    daily.outputTokens = 0
+    context.insert(daily)
+
+    let projectA = ProjectUsage(projectName: "app-a", tokens: 80)
+    projectA.dailyUsage = daily
+    daily.projectBreakdowns.append(projectA)
+    context.insert(projectA)
+
+    let projectB = ProjectUsage(projectName: "app-b", tokens: 70)
+    projectB.dailyUsage = daily
+    daily.projectBreakdowns.append(projectB)
+    context.insert(projectB)
+
+    try context.save()
+
+    let repository = OverviewRepository(modelContainer: container)
+    let snapshot = await repository.loadSnapshot()
+
+    #expect(snapshot.todayProjects.count == 2)
+    let appA = snapshot.todayProjects.first { $0.name == "app-a" }
+    let appB = snapshot.todayProjects.first { $0.name == "app-b" }
+    #expect(appA?.tokens == 80)
+    #expect(appB?.tokens == 70)
+}
+
+@Test @MainActor func loadSnapshot_excludesInactiveSessions() async throws {
+    let container = try makeContainer()
+    let context = ModelContext(container)
+
+    let active = SessionUsage(sessionId: "s1", projectName: "proj-a", startTime: Date())
+    active.isActive = true
+    active.totalTokens = 500
+    context.insert(active)
+
+    let dead = SessionUsage(sessionId: "s2", projectName: "proj-b", startTime: Date())
+    dead.isActive = false
+    dead.totalTokens = 300
+    context.insert(dead)
+
+    try context.save()
+
+    let repository = OverviewRepository(modelContainer: container)
+    let snapshot = await repository.loadSnapshot()
+
+    #expect(snapshot.activeSessions.count == 1)
+    #expect(snapshot.activeSessions.first?.sessionId == "s1")
+    #expect(snapshot.activeSessions.first?.totalTokens == 500)
+}
+
+// MARK: - loadHourlyTokens
+
+@Test @MainActor func loadHourlyTokens_bucketsHoursCorrectly() async throws {
+    let container = try makeContainer()
+    let context = ModelContext(container)
+
+    let today = Calendar.current.startOfDay(for: Date())
+    context.insert(HourlyUsage(date: today, hour: 0, tokens: 10))
+    context.insert(HourlyUsage(date: today, hour: 12, tokens: 500))
+    context.insert(HourlyUsage(date: today, hour: 23, tokens: 100))
+
+    try context.save()
+
+    let repository = OverviewRepository(modelContainer: container)
+    let hourly = await repository.loadHourlyTokens(for: today)
+
+    #expect(hourly.count == 24)
+    #expect(hourly[0] == 10)
+    #expect(hourly[12] == 500)
+    #expect(hourly[23] == 100)
+    // Boundary: hours with no entry are 0, not nil.
+    #expect(hourly[1] == 0)
+    #expect(hourly[22] == 0)
+}
+
+@Test @MainActor func loadHourlyTokens_ignoresOtherDates() async throws {
+    let container = try makeContainer()
+    let context = ModelContext(container)
+
+    let today = Calendar.current.startOfDay(for: Date())
+    let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: today)!
+
+    context.insert(HourlyUsage(date: today, hour: 5, tokens: 100))
+    context.insert(HourlyUsage(date: yesterday, hour: 5, tokens: 999))
+
+    try context.save()
+
+    let repository = OverviewRepository(modelContainer: container)
+    let hourly = await repository.loadHourlyTokens(for: today)
+
+    #expect(hourly[5] == 100)  // yesterday's 999 must not leak into today
+}
+
+// MARK: - loadProjects
+
+@Test @MainActor func loadProjects_returnsOnlyForRequestedDate() async throws {
+    let container = try makeContainer()
+    let context = ModelContext(container)
+
+    let today = Calendar.current.startOfDay(for: Date())
+    let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: today)!
+
+    let todayDaily = DailyUsage(date: today)
+    context.insert(todayDaily)
+    let todayProject = ProjectUsage(projectName: "todays-app", tokens: 100)
+    todayProject.dailyUsage = todayDaily
+    todayDaily.projectBreakdowns.append(todayProject)
+    context.insert(todayProject)
+
+    let yesterdayDaily = DailyUsage(date: yesterday)
+    context.insert(yesterdayDaily)
+    let yesterdayProject = ProjectUsage(projectName: "yesterdays-app", tokens: 300)
+    yesterdayProject.dailyUsage = yesterdayDaily
+    yesterdayDaily.projectBreakdowns.append(yesterdayProject)
+    context.insert(yesterdayProject)
+
+    try context.save()
+
+    let repository = OverviewRepository(modelContainer: container)
+    let projects = await repository.loadProjects(for: yesterday)
+
+    #expect(projects.count == 1)
+    #expect(projects.first?.name == "yesterdays-app")
+    #expect(projects.first?.tokens == 300)
+}

--- a/TokenGardenTests/OverviewViewModelTests.swift
+++ b/TokenGardenTests/OverviewViewModelTests.swift
@@ -1,0 +1,104 @@
+import Testing
+import SwiftData
+import Foundation
+@testable import TokenGarden
+
+@MainActor
+private func makeContainer() throws -> ModelContainer {
+    let config = ModelConfiguration(isStoredInMemoryOnly: true)
+    return try ModelContainer(
+        for: DailyUsage.self,
+        ProjectUsage.self,
+        SessionUsage.self,
+        HourlyUsage.self,
+        configurations: config
+    )
+}
+
+@Test @MainActor func vm_initialState_isLoading() async throws {
+    let container = try makeContainer()
+    let vm = OverviewViewModel(modelContainer: container)
+
+    // Before start(), the VM must be in the "loading" state so the view
+    // shows a skeleton rather than flashing empty content.
+    #expect(vm.isInitialLoading == true)
+    #expect(vm.snapshot.hasAnyData == false)
+    #expect(vm.selectedDate == nil)
+}
+
+@Test @MainActor func vm_start_flipsLoadingFalseAfterLoad() async throws {
+    let container = try makeContainer()
+    let vm = OverviewViewModel(modelContainer: container)
+
+    vm.start()
+    await vm.awaitPendingTasks()
+
+    #expect(vm.isInitialLoading == false)
+    #expect(vm.snapshot.hasAnyData == false)  // empty DB
+}
+
+@Test @MainActor func vm_start_loadsSnapshotFromDB() async throws {
+    let container = try makeContainer()
+    let context = ModelContext(container)
+
+    let today = Calendar.current.startOfDay(for: Date())
+    let daily = DailyUsage(date: today)
+    daily.inputTokens = 300
+    daily.outputTokens = 200
+    context.insert(daily)
+    try context.save()
+
+    let vm = OverviewViewModel(modelContainer: container)
+    vm.start()
+    await vm.awaitPendingTasks()
+
+    #expect(vm.isInitialLoading == false)
+    #expect(vm.snapshot.hasAnyData == true)
+    #expect(vm.snapshot.todayTokens == 500)
+}
+
+@Test @MainActor func vm_selectedDate_triggersProjectLoad() async throws {
+    let container = try makeContainer()
+    let context = ModelContext(container)
+
+    let today = Calendar.current.startOfDay(for: Date())
+    let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: today)!
+
+    let daily = DailyUsage(date: yesterday)
+    context.insert(daily)
+    let project = ProjectUsage(projectName: "historical-app", tokens: 300)
+    project.dailyUsage = daily
+    daily.projectBreakdowns.append(project)
+    context.insert(project)
+    try context.save()
+
+    let vm = OverviewViewModel(modelContainer: container)
+    vm.start()
+    await vm.awaitPendingTasks()
+
+    // No selection yet → selectedDayProjects should be nil
+    #expect(vm.selectedDayProjects == nil)
+
+    // Selecting yesterday should trigger a background fetch
+    vm.selectedDate = yesterday
+    await vm.awaitPendingTasks()
+
+    #expect(vm.selectedDayProjects != nil)
+    #expect(vm.selectedDayProjects?.count == 1)
+    #expect(vm.selectedDayProjects?.first?.name == "historical-app")
+}
+
+@Test @MainActor func vm_selectedDate_nilResetsSelection() async throws {
+    let container = try makeContainer()
+    let vm = OverviewViewModel(modelContainer: container)
+
+    vm.start()
+    await vm.awaitPendingTasks()
+
+    vm.selectedDate = Date()
+    await vm.awaitPendingTasks()
+
+    // Setting to nil must clear selectedDayProjects synchronously.
+    vm.selectedDate = nil
+    #expect(vm.selectedDayProjects == nil)
+}


### PR DESCRIPTION
## Summary

Saved profiles disappear silently after an app crash. Two interacting bugs in `AppDelegate.applicationDidFinishLaunching` caused this:

1. **`backupProfiles` ignored WAL.** It called `sqlite3_open` and `SELECT FROM ZPROFILE` without checkpointing the write-ahead log first. If the previous process crashed before SQLite checkpointed (e.g. the `EXC_CRASH` in `_PFFaultHandlerLookupRow` on 2026-04-10), recently-saved profiles lived only in `TokenGarden.store-wal` and were invisible to the SELECT.
2. **Reset path destroyed the store regardless.** `catch { ... try? FileManager.default.removeItem(at: storeDir) ... }` ran unconditionally. An empty backup was treated the same as "no profiles existed", so the old store (and its WAL, which still held the profiles) was deleted.

Net effect on 2026-04-10: a single crash → next launch's ModelContainer init failed → backup returned zero rows despite profiles existing in WAL → store removed → profiles gone, no recovery path.

## Fix

- `backupProfiles` now runs `PRAGMA wal_checkpoint(TRUNCATE)` before reading. WAL-only rows are folded into the main DB and become visible to the SELECT.
- New `ProfileBackupResult` distinguishes three cases: read DB with N profiles / read DB with 0 profiles / couldn't read DB at all (missing file, schema mismatch, etc.). Callers get an authoritative "backup is trustworthy" signal.
- Replaced `FileManager.removeItem` with `archiveStoreFiles`, which renames `TokenGarden.store`, `-shm`, and `-wal` to timestamped `*.corrupted-<iso>` siblings. Recovery becomes manual but impossible to silently lose.

## Test plan

New `AppDelegateProfileBackupTests` (Swift Testing, `@MainActor`):

- [x] `backupProfiles reads rows even when they live only in the WAL` — creates a WAL-resident insert, asserts backup returns the profile.
- [x] `backupProfiles returns didReadDatabase=false when file is missing` — missing store file reports unreliable empty result.
- [x] `backupProfiles returns didReadDatabase=false when ZPROFILE is absent` — schema mismatch reports unreliable empty result instead of pretending the table is empty.
- [x] `archiveStoreFiles renames store + wal + shm instead of deleting` — verifies all three files move to `.corrupted-*` siblings.
- [x] Full suite: 36 tests pass, 0 fail (`xcodebuild ... test`).